### PR TITLE
[SofaQtQuickGUI] Sofa master compat

### DIFF
--- a/applications-dev/plugins/SofaQtQuickGUI/CMakeLists.txt
+++ b/applications-dev/plugins/SofaQtQuickGUI/CMakeLists.txt
@@ -279,7 +279,7 @@ if(NOT MSVC)
 endif()
 
 ## Install rules for the library; CMake package configurations files
-sofa_generate_package(NAME ${PROJECT_NAME} VERSION ${SOFAQTQUICKGUI_VERSION} TARGETS ${PROJECT_NAME} INCLUDES ${PROJECT_NAME})
+sofa_generate_package(NAME ${PROJECT_NAME} VERSION ${SOFAQTQUICKGUI_VERSION} TARGETS ${PROJECT_NAME} INCLUDE_ROOT_DIR ${PROJECT_NAME})
 
 if(SOFA_BUILD_TESTS)
     find_package(SofaTest QUIET)

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Models/SofaSceneItemModel.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Models/SofaSceneItemModel.cpp
@@ -310,7 +310,7 @@ size_t rrowCount(Node* parent)
     return parent->child.size() + parent->object.size() ;
 }
 
-void SofaSceneItemModel::addChild(Node* target, Node* child)
+void SofaSceneItemModel::beginAddChild(Node* target, Node* child)
 {
     msg_info("b") << "=========== Adding a child node to: " << target->getName();
 
@@ -323,11 +323,9 @@ void SofaSceneItemModel::addChild(Node* target, Node* child)
 
     beginInsertRows(parentIndex, i, i);
 
-    MutationListener::addChild(target,child);
-
 }
 
-void SofaSceneItemModel::addChildDone(Node* target, Node* child)
+void SofaSceneItemModel::endAddChild(Node* target, Node* child)
 {
     endInsertRows();
     //msg_info("b") << "========== Adding a child done: " << child->getName();

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Models/SofaSceneItemModel.h
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Models/SofaSceneItemModel.h
@@ -85,8 +85,8 @@ protected:
     /// The following function are inhereted from MutationLister, they are called when there is
     /// change in the scene this model is exposing. When called this function is function is in
     /// charge of notifying the change using the QAbstractItemModel.
-    void addChild(Node* parent, Node* child) override;
-    void addChildDone(Node* parent, Node* child) override;
+    void beginAddChild(Node* parent, Node* child) override;
+    void endAddChild(Node* parent, Node* child) override;
 
     //virtual void removeChild(Node* parent, Node* child) override;
     //virtual void addObject(Node* parent, sofa::core::objectmodel::BaseObject* object) override;

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Models/SofaSceneListModel.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Models/SofaSceneListModel.cpp
@@ -55,13 +55,13 @@ void SofaSceneListModel::handleSceneChange(SofaScene*)
     if(mySofaScene)
     {
         if(mySofaScene->isReady())
-            addChild(0, mySofaScene->sofaRootNode().get());
+            addChildBegin(0, mySofaScene->sofaRootNode().get());
 
         connect(mySofaScene, &SofaScene::statusChanged, this, [this]() {
             clear();
 
             if(SofaScene::Ready == mySofaScene->status())
-                addChild(0, mySofaScene->sofaRootNode().get());
+                addChildBegin(0, mySofaScene->sofaRootNode().get());
         });
     }
 }
@@ -333,7 +333,7 @@ unsigned int SofaSceneListModel::countChildrenOf(const SofaSceneListModel::Item&
     return count;
 }
 
-void SofaSceneListModel::addChild(Node* parent, Node* child)
+void SofaSceneListModel::beginAddChild(Node* parent, Node* child)
 {
     if(!child)
         return;
@@ -344,7 +344,6 @@ void SofaSceneListModel::addChild(Node* parent, Node* child)
         beginInsertRows(QModelIndex(), 0, 0);
         myItems.append(buildNodeItem(0, child));
         endInsertRows();
-        MutationListener::addChild(parent, child);
         return ;
     }
 
@@ -375,16 +374,12 @@ void SofaSceneListModel::addChild(Node* parent, Node* child)
 
     parentItem.children.append(&*newChildItemIt);
     endInsertRows();
-
-    MutationListener::addChild(parent, child);
 }
 
-void SofaSceneListModel::removeChild(Node* parent, Node* child)
+void SofaSceneListModel::endRemoveChild(Node* parent, Node* child)
 {
     if(!child)
         return;
-
-    MutationListener::removeChild(parent, child);
 
     QList<Item>::iterator itemIt = myItems.begin();
     while(itemIt != myItems.end())
@@ -415,7 +410,7 @@ void SofaSceneListModel::removeChild(Node* parent, Node* child)
     }
 }
 
-void SofaSceneListModel::addObject(Node* parent, BaseObject* object)
+void SofaSceneListModel::beginAddObject(Node* parent, BaseObject* object)
 {
     if(!object || !parent)
         return;
@@ -452,16 +447,12 @@ void SofaSceneListModel::addObject(Node* parent, BaseObject* object)
                 ++parentItemIt;
         }
     }
-
-    MutationListener::addObject(parent, object);
 }
 
-void SofaSceneListModel::removeObject(Node* parent, BaseObject* object)
+void SofaSceneListModel::endRemoveObject(Node* parent, BaseObject* object)
 {
     if(!object || !parent)
         return;
-
-    MutationListener::removeObject(parent, object);
 
     QList<Item>::iterator itemIt = myItems.begin();
     while(itemIt != myItems.end())

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Models/SofaSceneListModel.h
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Models/SofaSceneListModel.h
@@ -79,10 +79,10 @@ signals:
 protected:
 
     /// The following function are inhereted from MutationLister
-    virtual void addChild(sofa::simulation::Node* parent, sofa::simulation::Node* child) override;
-    virtual void removeChild(sofa::simulation::Node* parent, sofa::simulation::Node* child) override;
-    virtual void addObject(sofa::simulation::Node* parent, sofa::core::objectmodel::BaseObject* object) override;
-    virtual void removeObject(sofa::simulation::Node* parent, sofa::core::objectmodel::BaseObject* object)override;
+    virtual void beginAddChild(sofa::simulation::Node* parent, sofa::simulation::Node* child) override;
+    virtual void endRemoveChild(sofa::simulation::Node* parent, sofa::simulation::Node* child) override;
+    virtual void beginAddObject(sofa::simulation::Node* parent, sofa::core::objectmodel::BaseObject* object) override;
+    virtual void endRemoveObject(sofa::simulation::Node* parent, sofa::core::objectmodel::BaseObject* object)override;
 
 
 private:

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaScene.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaScene.cpp
@@ -186,7 +186,7 @@ bool LoaderProcess(SofaScene* sofaScene)
     if( sofaScene->sofaRootNode() )
     {
         sofaScene->sofaSimulation()->init(sofaScene->sofaRootNode().get());
-        sofaScene->addChild(0, sofaScene->sofaRootNode().get());
+        sofaScene->addChildBegin(nullptr, sofaScene->sofaRootNode().get());
 
         if(sofaScene->sofaRootNode()->getAnimate() || sofaScene->defaultAnimate())
             sofaScene->setAnimate(true);
@@ -1724,42 +1724,34 @@ void SofaScene::onKeyReleased(char key)
     sofaRootNode()->propagateEvent(sofa::core::ExecParams::defaultInstance(), &keyEvent);
 }
 
-void SofaScene::addChild(Node* parent, Node* child)
+void SofaScene::beginAddChild(Node* parent, Node* child)
 {
     if(!child)
         return;
 
     myBases.insert(child);
-
-    MutationListener::addChild(parent, child);
 }
 
-void SofaScene::removeChild(Node* parent, Node* child)
+void SofaScene::endRemoveChild(Node* parent, Node* child)
 {
     if(!child)
         return;
 
-    MutationListener::removeChild(parent, child);
-
     myBases.remove(child);
 }
 
-void SofaScene::addObject(Node* parent, BaseObject* object)
+void SofaScene::beginAddObject(Node* parent, BaseObject* object)
 {
     if(!object || !parent)
         return;
 
     myBases.insert(object);
-
-    MutationListener::addObject(parent, object);
 }
 
-void SofaScene::removeObject(Node* parent, BaseObject* object)
+void SofaScene::endRemoveObject(Node* parent, BaseObject* object)
 {
     if(!object || !parent)
         return;
-
-    MutationListener::removeObject(parent, object);
 
     myBases.remove(object);
 }

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaScene.h
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaScene.h
@@ -267,10 +267,10 @@ protected:
     SelectableSofaParticle* pickParticle(const QVector3D& origin, const QVector3D& direction, double distanceToRay, double distanceToRayGrowth, const QStringList& tags, const QList<SofaComponent*>& roots = QList<SofaComponent*>());
 
 protected:
-    void addChild(sofa::simulation::Node* parent, sofa::simulation::Node* child);
-    void removeChild(sofa::simulation::Node* parent, sofa::simulation::Node* child);
-    void addObject(sofa::simulation::Node* parent, sofa::core::objectmodel::BaseObject* object);
-    void removeObject(sofa::simulation::Node* parent, sofa::core::objectmodel::BaseObject* object);
+    void beginAddChild(sofa::simulation::Node* parent, sofa::simulation::Node* child);
+    void endRemoveChild(sofa::simulation::Node* parent, sofa::simulation::Node* child);
+    void beginAddObject(sofa::simulation::Node* parent, sofa::core::objectmodel::BaseObject* object);
+    void endRemoveObject(sofa::simulation::Node* parent, sofa::core::objectmodel::BaseObject* object);
 
 private:
     Status                                      myStatus;


### PR DESCRIPTION
This PR applies the changes necessary to be compatible again with the master branch of SOFA.
More specifically, it ensures compatibility with the sofaMaster_compat branch in SofaDefrost/sofa, which basically is sofa_framework/sofa:master with a rebase of clean_mutationListener & sofa_generate_package.

Once PR #909 & #917 will be merged in sofa-framework/master, we'll be back on track