### PR TITLE
Fixing focus issues

### DIFF
--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaBasics/TextField.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaBasics/TextField.qml
@@ -13,7 +13,6 @@ TextField {
     leftPadding: 7
     rightPadding: 7
     hoverEnabled: true
-
     background: ControlsBackground {
         id: backgroundID
         implicitWidth: 50

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_number.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_number.qml
@@ -46,6 +46,7 @@ TextField
 
     onAccepted:
     {
+        sofaData.value = getValue()
         focus = false
     }
 
@@ -53,7 +54,7 @@ TextField
     {
         if(!activeFocus)
         {
-            upload()
+            sofaData.value = getValue()
         }
     }
 
@@ -125,15 +126,4 @@ TextField
 
     validator: decimals > 0 ? doubleValidator : intValidator
 
-//    function download() {
-//        root.text = Number(Number(dataObject.value).toFixed(decimals)).toString();
-//        cursorPosition = 0;
-//        console.log("DOWNLOADING DATA FROM: "+dataObject.name)
-//    }
-
-//    function upload() {
-//        console.log("XUPLOADING DATA TO: "+dataObject.name)
-//        var newValue = Number(Number(root.text).toFixed(decimals));
-//        dataObject.value = newValue;
-//    }
 }

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_string.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_string.qml
@@ -41,5 +41,6 @@ TextField {
     onAccepted:
     {
         sofaData.value = text
+        root.focus = false
     }
 }

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaViews/Inspector.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaViews/Inspector.qml
@@ -239,7 +239,6 @@ Item {
                             model : VisualDataModel {
                                 property int parentIndex:
                                 {
-                                    console.log("setting parentIndex/grroupIndex....."+theItem.groupIndex )
                                     theItem.groupIndex
                                 }
 

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaViews/LiveInterfaceEditor.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaViews/LiveInterfaceEditor.qml
@@ -43,16 +43,17 @@ QQC1.SplitView {
     }
 
     onFilesChanged: {
-            container.children=""
-            /// Reload the component using the non cached version (because of Data.now())
-            var viewedcomponent=Qt.createComponent("file://"+files+"?t="+Date.now())
-            if(viewedcomponent.status == Component.Ready)
-            {
-                viewedcomponent.createObject(container)
-                console.log("Component updated !!!")
-            }else{
-                var err = viewedcomponent.errorString();
-                console.log("Error at " + err + "<br />")
-            }
+        container.children=""
+        console.error(files)
+        /// Reload the component using the non cached version (because of Data.now())
+        var viewedcomponent=Qt.createComponent("file://"+files+"?t="+Date.now())
+        if(viewedcomponent.status === Component.Ready)
+        {
+            viewedcomponent.createObject(container)
+            console.log("Component updated !!!")
+        }else{
+            var err = viewedcomponent.errorString();
+            console.log("Error at " + err + "<br />")
+        }
     }
 }

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaWidgets/SofaAssetMenu.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaWidgets/SofaAssetMenu.qml
@@ -72,17 +72,19 @@ Menu {
 
             function createAsset() {
                 var newNode = asset.create(assetName)
-                var hasNodes = newNode.getChildren().size()
-                console.error("ParentNode address: " + parentNode)
-                console.error("ParentNode Name: " + parentNode.getName())
-                newNode.copyTo(parentNode)
-                if (hasNodes) {
-                    var childsList = parentNode.getChildren()
-                    if (childsList.size() !== 0) {
-                        return childsList.last()
-                    }
-                }
-                return parentNode
+//                var hasNodes = newNode.getChildren().size()
+//                console.error("ParentNode address: " + parentNode)
+//                console.error("ParentNode Name: " + parentNode.getName())
+//                newNode.copyTo(parentNode)
+//                if (hasNodes) {
+//                    var childsList = parentNode.getChildren()
+//                    if (childsList.size() !== 0) {
+//                        return childsList.last()
+//                    }
+//                }
+//                return parentNode
+                parentNode.addChild(newNode)
+                return newNode
             }
 
             ToolTip {

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaData.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaData.cpp
@@ -126,7 +126,7 @@ bool SofaData::setLink(const QString& path)
 
 QString SofaData::getHelp() const
 {
-    return rawData()->getHelp();
+    return rawData()->getHelp().c_str();
 
 }
 
@@ -142,7 +142,7 @@ bool SofaData::isReadOnly() const
 
 QString SofaData::getGroup() const
 {
-    return rawData()->getGroup();
+    return rawData()->getGroup().c_str();
 }
 
 } /// namespace sofaqtquick::bindings

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/DataHelper.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/DataHelper.cpp
@@ -422,7 +422,7 @@ QVariantMap& convertDataInfoToProperties(const BaseData* data, QVariantMap& prop
         return properties;
     }
 
-    QString widget(data->getWidget());
+    QString widget(data->getWidget().c_str());
     if(!widget.isEmpty())
     {
         properties.insert("type",widget);
@@ -540,7 +540,7 @@ QVariantMap getSofaDataProperties(const sofa::core::objectmodel::BaseData* data)
         properties.insert("autoUpdate", true);
     }
 
-    QString widget(data->getWidget());
+    QString widget(data->getWidget().c_str());
     if(!widget.isEmpty())
         type = widget;
 
@@ -548,9 +548,9 @@ QVariantMap getSofaDataProperties(const sofa::core::objectmodel::BaseData* data)
 
     //object.insert("sofaData", QVariant::fromValue(sofaData));
     object.insert("name", data->getName().c_str());
-    object.insert("description", data->getHelp());
+    object.insert("description", data->getHelp().c_str());
     object.insert("type", type);
-    object.insert("group", data->getGroup());
+    object.insert("group", data->getGroup().c_str());
     object.insert("properties", properties);
     object.insert("link", QString::fromStdString(data->getLinkPath()));
     object.insert("value", createQVariantFromData(data));

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Models/SofaDataListModel.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Models/SofaDataListModel.cpp
@@ -146,7 +146,7 @@ SofaDataListModel::Item SofaDataListModel::buildItem(BaseData* data) const
     SofaDataListModel::Item item;
 
     item.name = QString::fromStdString(data->getName());
-    item.group = data->getGroup();
+    item.group = data->getGroup().c_str();
     item.type = SofaDataType;
     item.data = QVariant::fromValue((void*) data);
 

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Models/SofaInspectorDataListModel.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Models/SofaInspectorDataListModel.cpp
@@ -83,23 +83,23 @@ void SofaInspectorDataListModel::update()
             QString baseString("Base");
             for(BaseData* data : base->getDataFields())
             {
-                const char* gname = data->getGroup() ;
-                if(strlen(gname)==0){
-                    gname = data->getOwnerClass() ;
+                std::string gname = data->getGroup() ;
+                if(gname.empty()){
+                    gname = data->getOwnerClass();
                 }
 
-                if( QString("Context") == QString(gname) )
+                if( QString("Context") == QString(gname.c_str()) )
                 {
                     gname="Base";
                 }
-                else if( QString("BaseObject") == QString(gname) )
+                else if( QString("BaseObject") == QString(gname.c_str()) )
                 {
                     gname="Base";
                 }
 
-                if( QString("Infos") != QString(gname) )
+                if( QString("Infos") != QString(gname.c_str()) )
                 {
-                    ItemGroup* ig = findOrCreateGroup(getGroupName(QString(gname),
+                    ItemGroup* ig = findOrCreateGroup(getGroupName(QString(gname.c_str()),
                                                                    baseString)) ;
                     ig->m_children.append(new Item(QString::fromStdString(data->getName()),
                                                    QVariant::fromValue((void*)data),


### PR DESCRIPTION
Few fixes:

1. Removes the need for @SofaPrefab decorator by creating prefab datafields on instantiation. More stuff are retrieved from introspection
    - Source code
    - module name / path 
    - Line of instantiation
    - list of names of the callable's arguments
2. Reverts how prefab nodes are instantiated (new node created instead of copying its content)
3. Adapting retrieval of help string / group name from BaseData to match [PR #1152](https://github.com/sofa-framework/sofa/pull/1152)
