### PR TITLE
Multiple fixes in SofaDataTypes

### DIFF
--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaBasics/SpinBox.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaBasics/SpinBox.qml
@@ -39,7 +39,7 @@ Rectangle {
     property string suffix: ""  // a suffix for this spinbox (for instance a unit of measure)
     property int decimals: 2  // the number of decimals (0 for integers)
     property double step: 0.1  // the step size to scale mouse / indicators interactions
-    property double value: 50.0  // the value stored in this spinbox
+    property double value: 42250.0  // the value stored in this spinbox
 
     property alias cornerPositions: backgroundID.cornerPositions
     property alias position: backgroundID.position
@@ -63,9 +63,12 @@ Rectangle {
         var str = ""
         if (prefix !== "")
             str += qsTr(prefix)
-        str += qsTr("%1").arg(v.toFixed(decimals))
+        var fixedValue = v.toFixed(decimals).toString()
+        if ((fixedValue.length - decimals - 1 ) > 4)
+            fixedValue = Number(fixedValue).toExponential(3)
+        str += fixedValue
         if (suffix !== "")
-            str += qsTr(suffix)
+            str += qsTr(suffix) + " "
         return str
     }
     function setValue(initialValue, incrVal)
@@ -169,6 +172,7 @@ Rectangle {
                 color: control.enabled ? "black" : "#464646"
                 horizontalAlignment: Qt.AlignHCenter
                 verticalAlignment: Qt.AlignVCenter
+                clip: true
                 MouseArea {
                     id: contentMouseArea
 
@@ -224,6 +228,7 @@ Rectangle {
                 verticalAlignment: Qt.AlignVCenter
 
                 text: formatText(value, prefix, suffix).replace(prefix, "").replace(suffix, "")
+                clip: true
                 validator: DoubleValidator{}
                 color: control.enabled ? "black" : "#464646"
                 focus: true

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaBasics/SpinBox.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaBasics/SpinBox.qml
@@ -82,17 +82,17 @@ Rectangle {
 
     Rectangle {
         id: upIndicator
-        anchors.verticalCenter: parent.verticalCenter
+        anchors.verticalCenter: control.verticalCenter
         anchors.right: control.right
         width: 20
         implicitWidth: 20
-        height: parent.height
+        height: control.height
         visible: !isEditing && showIndicators
         color: "transparent"
         Image {
             id: rightup
-            x: control.mirrored ? 2 : parent.width - width - 2
-            y: parent.height / 4
+            x: control.mirrored ? 2 : upIndicator.width - width - 2
+            y: upIndicator.height / 4
             width: 9
             height: width
             source: "qrc:icon/spinboxRight.png"
@@ -120,17 +120,17 @@ Rectangle {
 
     Rectangle {
         id: downIndicator
-        anchors.verticalCenter: parent.verticalCenter
-        anchors.left: parent.left
+        anchors.verticalCenter: control.verticalCenter
+        anchors.left: control.left
         width: 20
         implicitWidth: 20
-        height: parent.height
+        height: control.height
         color: "transparent"
         visible: !isEditing && showIndicators
         Image {
             id: leftdown
-            x: control.mirrored ? parent.width - width - 2 : 2
-            y: parent.height / 4
+            x: control.mirrored ? downIndicator.width - width - 2 : 2
+            y: downIndicator.height / 4
             width: 9
             height: width
             source: "qrc:icon/spinboxLeft.png"
@@ -159,9 +159,9 @@ Rectangle {
 
     Rectangle {
         id: content
-        anchors.left: isEditing || !showIndicators ? parent.left : downIndicator.right
-        anchors.right: isEditing || !showIndicators ? parent.right: upIndicator.left
-        anchors.verticalCenter: parent.verticalCenter
+        anchors.left: isEditing || !showIndicators ? control.left : downIndicator.right
+        anchors.right: isEditing || !showIndicators ? control.right: upIndicator.left
+        anchors.verticalCenter: control.verticalCenter
         color: "transparent"
         implicitWidth: modeLoader.item.implicitWidth
         implicitHeight: 20
@@ -186,7 +186,7 @@ Rectangle {
                     property var initialPosition : Qt.vector2d(0,0)
                     property var initialValue
 
-                    anchors.fill: parent
+                    anchors.fill: labelID
                     hoverEnabled: true
                     acceptedButtons: !control.readOnly && control.enabled ? Qt.LeftButton : Qt.NoButton
 

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaBasics/SpinBox.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaBasics/SpinBox.qml
@@ -32,7 +32,8 @@ import SofaBasics 1.0 as SB
 Rectangle {
     id: control
 
-    property bool enabled: true  // like in other QtQuick controls, enables / disables the edition of this control
+    property bool readOnly: false // like in other QtQuick controls, enables / disables edition for this control
+    property bool enabled: true  // like in other QtQuick controls, enables / disables the edition of this control & grays it out
     property bool showIndicators: true  // shows / hides the up / down indicators for this spinBox
 
     property string prefix: ""  // a prefix for this spinbox (the name of the variable for instance "x: ")
@@ -101,14 +102,14 @@ Rectangle {
             id: upMouseArea
             anchors.fill: upIndicator
             hoverEnabled: true
-            acceptedButtons: control.enabled ? Qt.LeftButton : Qt.NoButton
+            acceptedButtons: !control.readOnly && control.enabled ? Qt.LeftButton : Qt.NoButton
 
             onHoveredChanged: {
                 cursorShape = Qt.ArrowCursor
                 if (containsMouse) {
-                    backgroundID.setControlState(control.enabled, containsMouse, upIndicator.focus)
+                    backgroundID.setControlState(control.enabled, containsMouse || control.readOnly, upIndicator.focus)
                 } else {
-                    backgroundID.setControlState(control.enabled, containsMouse, upIndicator.focus)
+                    backgroundID.setControlState(control.enabled, containsMouse || control.readOnly, upIndicator.focus)
                 }
             }
             onClicked: {
@@ -138,15 +139,17 @@ Rectangle {
             id: downMouseArea
             anchors.fill: downIndicator
             hoverEnabled: true
-            acceptedButtons: control.enabled ? Qt.LeftButton : Qt.NoButton
+            acceptedButtons: !control.readOnly && control.enabled ? Qt.LeftButton : Qt.NoButton
+
             onHoveredChanged: {
                 cursorShape = Qt.ArrowCursor
                 if (containsMouse) {
-                    backgroundID.setControlState(control.enabled, containsMouse, upIndicator.focus)
+                    backgroundID.setControlState(control.enabled, containsMouse || control.readOnly, upIndicator.focus)
                 } else {
-                    backgroundID.setControlState(control.enabled, containsMouse, upIndicator.focus)
+                    backgroundID.setControlState(control.enabled, containsMouse || control.readOnly, upIndicator.focus)
                 }
             }
+
 
             onClicked: {
                 control.setValue(control.value, -control.step)
@@ -181,16 +184,16 @@ Rectangle {
 
                     anchors.fill: parent
                     hoverEnabled: true
-                    acceptedButtons: control.enabled ? Qt.LeftButton : Qt.NoButton
+                    acceptedButtons: !control.readOnly && control.enabled ? Qt.LeftButton : Qt.NoButton
 
                     onHoveredChanged: {
-                        if (control.enabled) {
+                        if (control.enabled && !control.readOnly) {
                             cursorShape = Qt.SizeHorCursor
                         }
                         if (containsMouse) {
-                            backgroundID.setControlState(control.enabled, containsMouse, upIndicator.focus)
+                            backgroundID.setControlState(control.enabled, containsMouse || control.readOnly, upIndicator.focus)
                         } else {
-                            backgroundID.setControlState(control.enabled, containsMouse, upIndicator.focus)
+                            backgroundID.setControlState(control.enabled, containsMouse || control.readOnly, upIndicator.focus)
                         }
                     }
 
@@ -242,6 +245,10 @@ Rectangle {
                     forceActiveFocus()
                     selectAll()                    
                 }
+                position: backgroundID.position
+                enabled: control.enabled
+                readOnly: control.readOnly
+
             }
         }
 
@@ -250,14 +257,13 @@ Rectangle {
             sourceComponent: spinBoxMode
             anchors.fill: parent
         }
-
     }
 
     onEnabledChanged: {
-        backgroundID.setControlState(control.enabled, false, control.focus)
+        backgroundID.setControlState(control.enabled, control.readOnly ? true : false, control.focus)
     }
     Component.onCompleted: {
-        backgroundID.setControlState(control.enabled, false, control.focus)
+        backgroundID.setControlState(control.enabled, control.readOnly ? true : false, control.focus)
     }
 
     ControlsBackground {

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaBasics/SpinBox.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaBasics/SpinBox.qml
@@ -168,14 +168,18 @@ Rectangle {
 
         Component {
             id: spinBoxMode
-            Label {
+            TextInput {
                 id: labelID
+
                 anchors.centerIn: parent
-                text: formatText(value, prefix, suffix)
-                color: control.enabled ? "black" : "#464646"
                 horizontalAlignment: Qt.AlignHCenter
                 verticalAlignment: Qt.AlignVCenter
+
+                text: formatText(value, prefix, suffix)
+                color: control.enabled ? (control.readOnly ? "#393939" : "black") : "#464646"
                 clip: true
+                selectByMouse: control.readOnly || control.enabled ? true : false
+                readOnly: true
                 MouseArea {
                     id: contentMouseArea
 
@@ -233,7 +237,7 @@ Rectangle {
                 text: formatText(value, prefix, suffix).replace(prefix, "").replace(suffix, "")
                 clip: true
                 validator: DoubleValidator{}
-                color: control.enabled ? "black" : "#464646"
+                color: control.readOnly ? "#393939" : "black"
                 focus: true
                 selectByMouse: true
                 onEditingFinished: {

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaBasics/TextField.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaBasics/TextField.qml
@@ -9,7 +9,7 @@ TextField {
 
     id: control
     placeholderText: qsTr("None")
-    color: readOnly ? "#464646" : "black"
+    color: control.enabled ? (readOnly ? "#393939" : "black") : "#464646"
     leftPadding: 7
     rightPadding: 7
     hoverEnabled: true

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaBasics/TextField.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaBasics/TextField.qml
@@ -23,13 +23,13 @@ TextField {
     }
 
     onActiveFocusChanged: {
-        backgroundID.setControlState(control.enabled && !control.readOnly, control.hovered, control.activeFocus)
+        backgroundID.setControlState(control.enabled, control.hovered || control.readOnly, control.activeFocus)
     }
     onHoveredChanged: {
-        backgroundID.setControlState(control.enabled && !control.readOnly, control.hovered, control.activeFocus)
+        backgroundID.setControlState(control.enabled, control.hovered || control.readOnly, control.activeFocus)
     }
     Component.onCompleted: {
-        backgroundID.setControlState(control.enabled && !control.readOnly, control.hovered, control.activeFocus)
+        backgroundID.setControlState(control.enabled, control.hovered || control.readOnly, control.activeFocus)
     }
 
 

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_BoundingBox.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_BoundingBox.qml
@@ -58,13 +58,10 @@ ColumnLayout {
             Layout.fillWidth: true
 
             showIndicators: false
-            enabled: !sofaData.isReadOnly
+            readOnly: sofaData.isReadOnly
 
-            value: {
-                console.log(root.values[index])
-                console.log(root.values[index])
-                return root.values[index]
-            }
+            value: root.values[index]
+
             onValueChanged: {
                 if(!sofaData.isReadOnly) {
                     root.values[index] = value;
@@ -88,7 +85,7 @@ ColumnLayout {
             Layout.fillWidth: true
 
             showIndicators: false
-            enabled: !sofaData.isReadOnly
+            readOnly: sofaData.isReadOnly
 
             value: root.values[index]
             onValueChanged: {
@@ -113,7 +110,7 @@ ColumnLayout {
             Layout.fillWidth: true
 
             showIndicators: false
-            enabled: !sofaData.isReadOnly
+            readOnly: sofaData.isReadOnly
 
             value: root.values[index]
             onValueChanged: {
@@ -149,7 +146,7 @@ ColumnLayout {
             Layout.fillWidth: true
 
             showIndicators: false
-            enabled: !sofaData.isReadOnly
+            readOnly: sofaData.isReadOnly
 
             value: root.values[index]
             onValueChanged: {
@@ -175,7 +172,7 @@ ColumnLayout {
             Layout.fillWidth: true
 
             showIndicators: false
-            enabled: !sofaData.isReadOnly
+            readOnly: sofaData.isReadOnly
 
             value: root.values[index]
             onValueChanged: {
@@ -200,7 +197,7 @@ ColumnLayout {
             Layout.fillWidth: true
 
             showIndicators: false
-            enabled: !sofaData.isReadOnly
+            readOnly: sofaData.isReadOnly
 
             value: root.values[index]
             onValueChanged: {

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_BoundingBox.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_BoundingBox.qml
@@ -60,7 +60,11 @@ ColumnLayout {
             showIndicators: false
             enabled: !sofaData.isReadOnly
 
-            value: Number(root.values[index])
+            value: {
+                console.log(root.values[index])
+                console.log(root.values[index])
+                return root.values[index]
+            }
             onValueChanged: {
                 if(!sofaData.isReadOnly) {
                     root.values[index] = value;
@@ -86,7 +90,7 @@ ColumnLayout {
             showIndicators: false
             enabled: !sofaData.isReadOnly
 
-            value: Number(root.values[index])
+            value: root.values[index]
             onValueChanged: {
                 if(!sofaData.isReadOnly) {
                     root.values[index] = value;
@@ -111,7 +115,7 @@ ColumnLayout {
             showIndicators: false
             enabled: !sofaData.isReadOnly
 
-            value: Number(root.values[index])
+            value: root.values[index]
             onValueChanged: {
                 if(!sofaData.isReadOnly) {
                     root.values[index] = value;
@@ -147,7 +151,7 @@ ColumnLayout {
             showIndicators: false
             enabled: !sofaData.isReadOnly
 
-            value: Number(root.values[index])
+            value: root.values[index]
             onValueChanged: {
                 if(!sofaData.isReadOnly) {
                     root.values[index] = value;
@@ -173,7 +177,7 @@ ColumnLayout {
             showIndicators: false
             enabled: !sofaData.isReadOnly
 
-            value: Number(root.values[index])
+            value: root.values[index]
             onValueChanged: {
                 if(!sofaData.isReadOnly) {
                     root.values[index] = value;
@@ -198,7 +202,7 @@ ColumnLayout {
             showIndicators: false
             enabled: !sofaData.isReadOnly
 
-            value: Number(root.values[index])
+            value: root.values[index]
             onValueChanged: {
                 if(!sofaData.isReadOnly) {
                     root.values[index] = value;

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_ComponentStatus.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_ComponentStatus.qml
@@ -29,7 +29,7 @@ import Sofa.Core.SofaData 1.0
   *************************************************************************************************/
 Text {
     id: root
-    property SofaData dataObject: null
+    property SofaData sofaData: null
     enabled:true
-    text: dataObject===nullptr? "Missing" :  dataObject.value
+    text: sofaData===nullptr? "Missing" :  sofaData.value
 }

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_FileName.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_FileName.qml
@@ -38,18 +38,18 @@ Row {
     spacing : -1
     width: parent.width
 
-    property SofaData dataObject: null
+    property SofaData sofaData: null
 
     TextField {
         id: textField
         enabled: true
         width: root.width - openButton.width - root.spacing
-        text: undefined !== dataObject.value ? dataObject.value.toString() : ""
+        text: undefined !== sofaData.value ? sofaData.value.toString() : ""
 
         onAccepted: {
             /// Get the URL from the file chooser and convert it to a string.
-            dataObject.value = textField.text ;
-            dataObject.upload();
+            sofaData.value = textField.text ;
+            sofaData.upload();
         }
         position: cornerPositions["Left"]
 
@@ -84,8 +84,8 @@ Row {
         onClicked: {
             /// Open the FileDialog at the specified location.
             var url = "";
-            if( dataObject.properties.folderurl !== ""){
-                url = "file://"+dataObject.properties.folderurl
+            if( sofaData.properties.folderurl !== ""){
+                url = "file://"+sofaData.properties.folderurl
             }else{
                 url = SofaApplication.currentProject.rootDir
             }
@@ -100,11 +100,11 @@ Row {
     FileDialog {
         id: fileDialog
         title: "Please choose a file"
-        folder: "file://"+dataObject.properties.folderurl
+        folder: "file://"+sofaData.properties.folderurl
         onAccepted: {
             /// Get the URL from the file chooser and convert it to a string.
-            dataObject.value = fileDialog.fileUrl.toString().replace("file://","") ;
-            textField.text = dataObject.value.toString();
+            sofaData.value = fileDialog.fileUrl.toString().replace("file://","") ;
+            textField.text = sofaData.value.toString();
         }
     }
 

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_Material.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_Material.qml
@@ -24,16 +24,16 @@ import SofaBasics 1.0
 TextField {
     id: root
 
-    property var dataObject: null
+    property var sofaData: null
 
-    readOnly: dataObject.readOnly
-    enabled: !dataObject.readOnly
-    text: undefined !== dataObject.value ? dataObject.value.toString() : ""
+    readOnly: sofaData.readOnly
+    enabled: !sofaData.readOnly
+    text: undefined !== sofaData.value ? sofaData.value.toString() : ""
 
     Binding {
-        target: dataObject
+        target: sofaData
         property: "value"
         value: root.text
-        when: !dataObject.readOnly
+        when: !sofaData.readOnly
     }
 }

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_OptionsGroup.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_OptionsGroup.qml
@@ -27,29 +27,29 @@ import SofaBasics 1.0
   * an optiongroups have a dedicated property holding the possible choices represented with
   * string.
   * To access these choices you can use:
-  *   - root.dataObject.properties.choices
+  *   - root.sofaData.properties.choices
   *
   *************************************************************************************************/
 ComboBox {
     id: root
 
-    property var dataObject: null
+    property var sofaData
 
-    enabled: !dataObject.readOnly
+    enabled: !sofaData.readOnly
 
     model: {
-        return dataObject.properties.choices;
+        return sofaData.properties.choices;
     }
 
     onModelChanged: {
         var values = model.toString().split(',');
         for (var idx = 0 ; idx < values.length ; idx++)
-            if (values[idx] === dataObject.value)
+            if (values[idx] === sofaData.value)
                 currentIndex = idx;
     }
 
     onCurrentTextChanged: {
-        dataObject.value = currentText;
-        dataObject.upload();
+        sofaData.value = currentText;
+        sofaData.upload();
     }
 }

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_RGBAColor.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_RGBAColor.qml
@@ -36,18 +36,18 @@ Row {
     spacing : -1
     width: parent.width
 
-    property var dataObject: null
-    property var values: undefined !== dataObject.value ? dataObject.value[0] : []
+    property var sofaData: null
+    property var values: undefined !== sofaData.value ? sofaData.value[0] : []
 
     TextField {
         id: textField
         enabled: true
         width: root.width - colorChooser.width - root.spacing
-        text: undefined !== dataObject.value ? dataObject.value.toString() : ""
+        text: undefined !== sofaData.value ? sofaData.value.toString() : ""
 
         onAccepted: {
-            dataObject.value = [textField.text.split(',').map(Number)] ;
-            dataObject.upload();
+            sofaData.value = [textField.text.split(',').map(Number)] ;
+            sofaData.upload();
             colorChooser.setValueFromArray(values) ;
         }
     }
@@ -64,8 +64,8 @@ Row {
                             +", "+((1.0*g)).toFixed(2)
                             +", "+((1.0*b)).toFixed(2)
                             +", "+((1.0*a)).toFixed(2);
-            dataObject.value = [[r,g,b,a]] ;
-            dataObject.upload();
+            sofaData.value = [[r,g,b,a]] ;
+            sofaData.upload();
         }
     }
 }

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_string.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_string.qml
@@ -32,7 +32,6 @@ TextField {
     property var sofaData: null
     property int refreshCounter: 0
     readOnly: sofaData ? (sofaData.type !== "string" ? true : sofaData.readOnly) : sofaData.readOnly
-    enabled: !sofaData.readOnly
     text: sofaData.value.toString()
     implicitWidth: parent.width
 

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_widget_displayFlags.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_widget_displayFlags.qml
@@ -32,7 +32,7 @@ TreeView {
     implicitWidth: 300
     implicitHeight: flickableItem.contentHeight
 
-    property var dataObject: null
+    property var sofaData: null
 
     frameVisible: false
     headerVisible: false
@@ -46,7 +46,7 @@ TreeView {
     model: SofaDisplayFlagsTreeModel {
         id: displayFlagsModel
 
-        displayFlagsData: root.dataObject ? root.dataObject.dataObject : null
+        displayFlagsData: root.sofaData ? root.sofaData : null
     }
 
     Component.onCompleted: expandAll();

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/DataHelper.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/DataHelper.cpp
@@ -426,7 +426,7 @@ QVariantMap& convertDataInfoToProperties(const BaseData* data, QVariantMap& prop
     if(baseTypeinfo->FixedSize())
         properties.insert("innerStatic", true);
 
-    QString widget(data->getWidget());
+    QString widget = QString::fromStdString(data->getWidget());
     if(!widget.isEmpty())
     {
         properties.insert("type",widget);
@@ -544,7 +544,7 @@ QVariantMap getSofaDataProperties(const sofa::core::objectmodel::BaseData* data)
         properties.insert("autoUpdate", true);
     }
 
-    QString widget(data->getWidget());
+    QString widget(QString::fromStdString(data->getWidget()));
     if(!widget.isEmpty())
         type = widget;
 
@@ -552,9 +552,9 @@ QVariantMap getSofaDataProperties(const sofa::core::objectmodel::BaseData* data)
 
     //object.insert("sofaData", QVariant::fromValue(sofaData));
     object.insert("name", data->getName().c_str());
-    object.insert("description", data->getHelp());
+    object.insert("description", QString::fromStdString(data->getHelp()));
     object.insert("type", type);
-    object.insert("group", data->getGroup());
+    object.insert("group", QString::fromStdString(data->getGroup()));
     object.insert("properties", properties);
     object.insert("link", QString::fromStdString(data->getLinkPath()));
     object.insert("value", createQVariantFromData(data));


### PR DESCRIPTION
- SpinBox uses scientific notation when too long to fit
- Fixes the use of the readOnly property of SpinBoxes / TextFields
- Fixing wrong data name in SofaDataType widgets