### PR TITLE
Better View / Model for Container data fields

### DIFF
--- a/applications-dev/plugins/SofaQtQuickGUI/CMakeLists.txt
+++ b/applications-dev/plugins/SofaQtQuickGUI/CMakeLists.txt
@@ -260,7 +260,8 @@ set(HEADER_FILES ${HEADER_FILES}
 )
 
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${MOC_FILES} ${SOURCE_FILES} ${QRC_FILES} ${RESOURCE_FILES} ${QML_FILES} ${CONFIG_FILES} ${PYTHON_FILES} ${EXTRA_FILES} ${ASSET_TEMPLATES})
-target_link_libraries(${PROJECT_NAME} PUBLIC ${SOFAPYTHON_LIBRARY} SofaOpenglVisual SofaGeneralLoader SofaLoader SofaSimulationGraph SofaGraphComponent SofaBoundaryCondition SofaComponentBase SofaMeshCollision Qt5::Core Qt5::Gui Qt5::Widgets Qt5::QuickControls2 Qt5::Qml Qt5::Quick Qt5::WebEngine stdc++fs)
+target_link_libraries(${PROJECT_NAME} PUBLIC ${SOFAPYTHON_LIBRARY} SofaOpenglVisual SofaGeneralLoader SofaLoader SofaSimulationGraph SofaGraphComponent SofaBoundaryCondition SofaComponentBase SofaMeshCollision
+    Qt5::Core Qt5::Gui Qt5::Widgets Qt5::QuickControls2 Qt5::Qml Qt5::Quick Qt5::WebEngine stdc++fs)
 #target_link_libraries(${PROJECT_NAME} PRIVATE assimp)
 
 target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/>")

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaBasics/SofaDataItem.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaBasics/SofaDataItem.qml
@@ -28,7 +28,6 @@ Item {
     id: self
 
     implicitWidth: gridlayout.implicitWidth
-    implicitHeight: dataWidget.implicitHeight
 
     signal doubleClickedOnLabel;
 
@@ -77,7 +76,6 @@ Item {
             text: sofaData ? sofaData.name : ""
             font.italic: true
             color: "black"
-            width: parent.width
             clip: true
             elide: Text.ElideRight
 
@@ -179,7 +177,7 @@ Item {
             var component = SofaDataWidgetFactory.getWidgetForData(sofaData)
             var o = component.createObject(datawidget, {"sofaData": sofaData,
                                                 "Layout.fillWidth":true})
-            self.implicitHeight = Qt.binding(function(){ return o.implicitHeight < 20 ? 20 : o.implicitHeight })
+            self.height = Qt.binding(function(){ return (o.implicitHeight < 20 ? 20 : o.implicitHeight) +1 })
             o.visible = Qt.binding(function() { return !linkButton.checked })
         }
     }

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaViews/Inspector.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaViews/Inspector.qml
@@ -285,12 +285,12 @@ Item {
 
                                             id: sofaDataItem
                                             implicitWidth : theItem.width
-                                            implicitHeight: 20
+//                                            implicitHeight: 20
 
                                             sofaData: getObject(sofaInspectorDataListModel.getDataById(childModel.parentIndex, index))
                                             refreshCounter: topRect.refreshCounter
 
-                                            nameLabelWidth:200
+                                            nameLabelWidth:128
 
                                             property var cachedObject : null;
                                             function getObject(d){
@@ -312,7 +312,7 @@ Item {
                                             id: linkView
                                             spacing: 1
 
-                                            Text {
+                                            Label {
                                                 id: linkNameLabel
                                                 Layout.preferredWidth: 100
                                                 Layout.fillHeight: true
@@ -320,7 +320,20 @@ Item {
 
                                                 text: name
                                                 font.italic: true
+                                                color: "black"
                                                 verticalAlignment: Text.AlignVCenter;
+                                                clip: true
+                                                elide: Text.ElideRight
+
+                                                MouseArea {
+                                                    id: linkLabelMouseArea
+                                                    hoverEnabled: true
+                                                    anchors.fill: parent
+                                                }
+                                                ToolTip {
+                                                    text: name
+                                                    visible: linkLabelMouseArea.containsMouse
+                                                }
                                             }
                                             TextField {
                                                 Layout.fillWidth: true

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/DataHelper.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/DataHelper.cpp
@@ -415,8 +415,10 @@ QVariantMap& convertDataInfoToProperties(const BaseData* data, QVariantMap& prop
         return properties;
     }
 
-    int nbCols = typeinfo->size();
-    int nbRows = typeinfo->size(data->getValueVoidPtr()) / nbCols;
+    int nbCols = int(typeinfo->BaseType()->size());
+    if (nbCols == 1)
+        nbCols = int(typeinfo->size());
+    int nbRows = int(typeinfo->size(data->getValueVoidPtr()) / nbCols);
     properties.insert("cols", nbCols);
     properties.insert("rows", nbRows);
     if(typeinfo->FixedSize())

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Models/SofaDataContainerListModel.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Models/SofaDataContainerListModel.cpp
@@ -7,7 +7,8 @@ namespace sofaqtquick {
 
 SofaDataContainerListModel::SofaDataContainerListModel(QObject* parent)
     : QAbstractTableModel(parent),
-      m_sofaData(nullptr)
+      m_sofaData(nullptr),
+      m_asGridViewModel(true)
 {
 
 }
@@ -25,6 +26,9 @@ int	SofaDataContainerListModel::rowCount(const QModelIndex & parent) const
 {
     if (parent.isValid())
         return 0;
+
+    if (m_asGridViewModel)
+        return m_sofaData->getProperties()["rows"].toInt() * m_sofaData->getProperties()["cols"].toInt();
     return m_sofaData->getProperties()["rows"].toInt();
 }
 
@@ -32,36 +36,95 @@ int	SofaDataContainerListModel::columnCount(const QModelIndex & parent) const
 {
     if (parent.isValid())
         return 0;
+
     return m_sofaData->getProperties()["cols"].toInt();
 }
 
-
-QVariant SofaDataContainerListModel::data(const QModelIndex &index, int role) const
+QString	SofaDataContainerListModel::getCornerType(const QModelIndex& idx) const
 {
-    size_t row = size_t(index.row());
-    size_t col = size_t(role);
+    int ncols = m_sofaData->getProperties()["cols"].toInt();
+    int nrows = m_sofaData->getProperties()["rows"].toInt();
+    int r = idx.row() / ncols;
+    int c = idx.row() % ncols;
 
-    if (index == QModelIndex() || col == 0)
-        return QVariant::fromValue(index.row());
+    bool top = r == 0;
+    bool bottom = r == nrows - 1;
+    bool left = c == 0;
+    bool right = c == ncols - 1;
+
+    bool singleColumn = ncols == 1;
+    bool singleRow = nrows == 1;
+
+    if (singleColumn && singleRow)
+        return "Single";
+    if (singleColumn && top)
+        return "Top";
+    if (singleColumn && bottom)
+        return "Bottom";
+    if (singleRow && left)
+        return "Left";
+    if (singleRow && right)
+        return "Right";
+    if (top && left)
+        return "TopLeft";
+    if (top && right)
+        return "TopRight";
+    if (bottom && left)
+        return "BottomLeft";
+    if (bottom && right)
+        return "BottomRight";
+    else
+        return "Middle";
+}
+
+QVariant SofaDataContainerListModel::data(const QModelIndex& index, int role) const
+{
+    size_t ncols = size_t(m_sofaData->getProperties()["cols"].toInt());
+    size_t row = 0;
+    size_t col = 0;
+    if (m_asGridViewModel)
+    {
+        if (role == CornerRole)
+        {
+            return getCornerType(index);
+        }
+        if (role == IndexRole)
+        {
+            return index;
+        }
+        // Add Here whatever role you might want to catch in the views
+
+        else if (role != ValueRole)
+            return QVariant();
+        row = size_t(index.row()) / ncols;
+        col = size_t(index.row()) % ncols;
+    }
+    else {
+        row = size_t(index.row());
+        col = size_t(role - 1);
+    }
+
 
     const AbstractTypeInfo* typeinfo = m_sofaData->rawData()->getValueTypeInfo();
 
+    std::cout << row << ":" << col << " = " << typeinfo->getScalarValue(
+                     m_sofaData->rawData()->getValueVoidPtr(),
+                     row * size_t(ncols) + col) << std::endl;
     if (typeinfo->Scalar())
         return QVariant::fromValue(typeinfo->getScalarValue(
                                        m_sofaData->rawData()->getValueVoidPtr(),
-                                       row * size_t(columnCount()) + (col-1)));
+                                       row * size_t(ncols) + col));
     else if (typeinfo->Integer())
         return QVariant::fromValue(typeinfo->getIntegerValue(
                                        m_sofaData->rawData()->getValueVoidPtr(),
-                                       row * size_t(columnCount()) + (col-1)));
+                                       row * size_t(ncols) + col));
     else
         return  QVariant();
 }
 
-
-QVariant SofaDataContainerListModel::headerData(int section, Qt::Orientation orientation, int role) const
-
+QVariant SofaDataContainerListModel::headerData(int section, Qt::Orientation orientation, int /*role*/) const
 {
+    ///  @bmarques TODO: use typename to determine column header titles
     if (orientation == Qt::Vertical) {
         return QVariant::fromValue<int>(section);
     }
@@ -75,27 +138,6 @@ QVariant SofaDataContainerListModel::headerData(int section, Qt::Orientation ori
             return QVariant::fromValue<QString>("y");
         case 2:
             return QVariant::fromValue<QString>("z");
-        case 3:
-            if (columnCount() == 4) // consider it to be a quaternion
-                return QVariant::fromValue<QString>("w");
-            else if (columnCount() == 6) {
-                return QVariant::fromValue<QString>("rx");
-            }
-            else {
-                return QVariant::fromValue<int>(section);
-            }
-        case 4:
-            if (columnCount() == 6) // consider it to be a quaternion
-                return QVariant::fromValue<QString>("ry");
-            else {
-                return QVariant::fromValue<int>(section);
-            }
-        case 5:
-            if (columnCount() == 6) // consider it to be a quaternion
-                return QVariant::fromValue<QString>("rz");
-            else {
-                return QVariant::fromValue<int>(section);
-            }
         default:
             return QVariant::fromValue<int>(section);
         }
@@ -104,25 +146,56 @@ QVariant SofaDataContainerListModel::headerData(int section, Qt::Orientation ori
 
 bool SofaDataContainerListModel::setData(const QModelIndex &index, const QVariant &value, int role)
 {
-    size_t row = size_t(index.row());
-    size_t col = size_t(role);
+    std::cout << "CHANGING DATA" << std::endl;
+    size_t row;
+    size_t col;
+    size_t ncols = size_t(m_sofaData->getProperties()["cols"].toInt());
 
-    if (index == QModelIndex() || col == 0)
-        return false;
-
+    if (m_asGridViewModel)
+    {
+        std::cout << "index: " << index.row() << ":" << index.column() << std::endl;
+        row = size_t(index.row()) / ncols;
+        col = size_t(index.row()) % ncols;
+    }
+    else {
+        row = size_t(index.row());
+        col = size_t(role - 1);
+    }
     const AbstractTypeInfo* typeinfo = m_sofaData->rawData()->getValueTypeInfo();
+    std::cout << "SetDATA: " << row << ":" << col << " => " << value.toReal() << std::endl;
 
     if (typeinfo->Scalar())
         typeinfo->setScalarValue(m_sofaData->rawData()->beginEditVoidPtr(),
-                                 row * size_t(columnCount()) + (col-1),
+                                 row * size_t(ncols) + col,
                                  value.toReal());
     else if (typeinfo->Integer())
         typeinfo->setScalarValue(m_sofaData->rawData()->beginEditVoidPtr(),
-                                 row * size_t(columnCount()) + (col-1),
+                                 row * size_t(ncols) + col,
                                  value.toInt());
     else
         return  false;
     return true;
+}
+
+
+QHash<int, QByteArray> SofaDataContainerListModel::roleNames() const {
+    QHash<int, QByteArray> roles;
+    if (m_asGridViewModel)
+    {
+        roles[CornerRole] = "corner";
+        roles[IndexRole] = "_index";
+        roles[ValueRole] = "dataValue";
+    }
+    else
+    {
+        for (auto i = 0 ; i < m_sofaData->property("cols").toInt() ; ++i)
+        {
+            std::string str("c");
+            str += std::to_string(i);
+            roles[ColumnRole+i] = str.c_str();
+        }
+    }
+    return roles;
 }
 
 }  // namespace sofaqtquick

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Models/SofaDataContainerListModel.h
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Models/SofaDataContainerListModel.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <QObject>
-#include <QAbstractTableModel>
+#include <QAbstractListModel>
 
 #include <SofaQtQuickGUI/Bindings/SofaData.h>
 
@@ -11,18 +11,34 @@ class SofaDataContainerListModel : public QAbstractTableModel
 {
     Q_OBJECT
 public:
+    enum DataContainerRoles {
+        CornerRole = Qt::UserRole + 1,
+        IndexRole,
+        ValueRole,
+        ColumnRole
+    };
+
     SofaDataContainerListModel(QObject* parent = nullptr);
 
 public:
     Q_PROPERTY(sofaqtquick::bindings::SofaData* sofaData READ sofaData WRITE setSofaData NOTIFY sofaDataChanged)
+    Q_PROPERTY(bool asGridViewModel READ asGridViewModel WRITE setAsGridViewModel NOTIFY asGridViewModelChanged)
+
+    inline int nCols() const { return m_sofaData ? m_sofaData->getProperties()["cols"].toInt() : 0; }
     inline sofaqtquick::bindings::SofaData* sofaData() const { return m_sofaData; }
+    inline bool asGridViewModel() const { return m_asGridViewModel; }
+
     void setSofaData(sofaqtquick::bindings::SofaData* newSofaData);
+    void setAsGridViewModel(bool asGridViewModel) { m_asGridViewModel = asGridViewModel; }
+
 signals:
     void sofaDataChanged(sofaqtquick::bindings::SofaData* newSofaData) const;
+    void asGridViewModelChanged(bool) const;
 
 protected:
+    QHash<int, QByteArray> roleNames() const;
     int	rowCount(const QModelIndex & parent = QModelIndex()) const;
-    int	columnCount(const QModelIndex & parent = QModelIndex()) const;
+    int columnCount(const QModelIndex & parent) const;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
     QVariant headerData(int section, Qt::Orientation orientation,
                         int role = Qt::DisplayRole) const;
@@ -31,6 +47,9 @@ protected:
                  int role = Qt::EditRole);
 private:
     sofaqtquick::bindings::SofaData* m_sofaData;
+    bool m_asGridViewModel;
+
+    QString getCornerType(const QModelIndex& idx) const;
 };
 
 }  // namespace sofaqtquick

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaQtQuickQmlModule.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaQtQuickQmlModule.cpp
@@ -265,6 +265,12 @@ void registerSofaTypesToQml(const char* /*uri*/)
         return SofaNode::createFrom(obj);
     });
 
+
+
+    sofa::Data<sofa::defaulttype::Vec3d> d(sofa::defaulttype::Vec3d(3,2,1),"dummy helpmsg");
+
+    SofaDataContainerListModel* model = new SofaDataContainerListModel();
+    model->setSofaData(new SofaData(&d));
 }
 
 void SofaQtQuickQmlModule::RegisterTypes(QQmlEngine* engine)


### PR DESCRIPTION
- only 2 different types of view for containers now:
    - static (i.e all container with a static size such as VecX, MatrixXY, Quat, etc.):
           Displayed as a GridView with no headers
    - dynamic (i.e all other containers, including those with innerStatic == true):
           Displayed as a TableView with horizontal header & row indices
- Both views use the same model (SofaDataContainerListModel) although sadly..: GridView & TableView behave too differently to use the same model so a boolean QML attribute (asGridViewModel) determines how columnCount(), rowCount() data() setData() roleNames() behave... -> yes, that sucks, but it was either that, or 2 different models for the same dataset type, which I didn't like either.
- Models are editable if !sofaData.isReadOnly

- TODO: Make dynamic tableView truly dynamic by allowing addition / removal of rows.
