### PR TITLE
Refactor how Prefab are handled in the GUI

### DIFF
--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaNode.h
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaNode.h
@@ -45,6 +45,7 @@ namespace _sofanode_
 using sofaqtquick::bindings::SofaBase;
 using sofaqtquick::bindings::_sofaobject_::SofaBaseObject;
 using sofa::simulation::graph::DAGNode;
+using sofa::core::objectmodel::BaseNode;
 
 class SofaNode;
 class SofaNodeList;

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaQtQuick_PythonEnvironment.h
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaQtQuick_PythonEnvironment.h
@@ -13,11 +13,17 @@
 #include <pybind11/eval.h>
 #pragma pop_macro("slots")
 
+namespace sofa::core::objectmodel { class Base; }
+
 namespace sofaqtquick {
 
 class SOFA_SOFAQTQUICKGUI_API PythonEnvironment
 {
 public:    
+    /// call a python function
+    static pybind11::object CallFunction(const QString& moduleName, const QString& functionName,
+                                         pybind11::list args, pybind11::dict kwargs, sofa::core::objectmodel::Base* b=nullptr);
+
     /// Retrieves the global docstring present in a python script
     static QString GetPythonModuleDocstring(const QString& modulePath);
 


### PR DESCRIPTION
- Move as much as possible the python calls into PythonEnvironment with proper try{} catch so an exception from python does not crash runSofa2 anymore. 
- Improve separability between py:: vs Qtstring, 
- There is now two way to make prefab 
1) inherit from Sofa.Core.Prefab 
2) use the @Sofa.PrefabBuilder decorator on a function. 
- remove the wizare to fill the variables, instead use the Inspector. 

Don't forget to update SofaPython3 to latest to take profit of this PR. 