### PR TITLE
Create empty Controller/DataEngine/ForceField

### DIFF
--- a/applications-dev/plugins/SofaQtQuickGUI/CMakeLists.txt
+++ b/applications-dev/plugins/SofaQtQuickGUI/CMakeLists.txt
@@ -174,6 +174,9 @@ endif ()
 set(ASSET_TEMPLATES
     data/config/templates/MeshAsset.py
     data/config/templates/PythonAsset.py
+    data/python/templates/emptyController.py
+    data/python/templates/emptyDataEngine.py
+    data/python/templates/emptyForceField.py
     )
 
 

--- a/applications-dev/plugins/SofaQtQuickGUI/data/python/templates/emptyController.py
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/python/templates/emptyController.py
@@ -1,0 +1,44 @@
+import Sofa.Core
+
+class %EmptyController%(Sofa.Core.Controller):
+    """ custom %EmptyController% component for SOFA """
+
+    def __init__(self, *args, **kwargs):
+        Sofa.Core.Controller.__init__(self, *args, **kwargs)
+        pass
+
+    def init(self):
+        pass
+    
+    def reinit(self):
+        pass
+    
+    # DEFAULT EVENTS:
+    def onAnimateBeginEvent(self, event):
+        """ called at the beginning of each time step """
+        pass
+
+    def onAnimateEndEvent(self, event):
+        """ called at the end of each time step """
+        pass
+
+    def onKeypressedEvent(self, event):
+        """ called when a key release event is triggered from the UI """
+        pass
+
+    def onKeyreleasedEvent(self, event):
+        """ called when a key release event is triggered from the UI """
+        pass
+
+    def onMouseEvent(self, event):
+        """ called when a mouse event is triggered from the UI """
+        pass
+
+    def onScriptEvent(self, event):
+        """ catches events sent from other python scripts """
+        pass
+
+    def onEvent(self, event):
+        """ generic method called when no script method exists for the sent event """
+        pass
+

--- a/applications-dev/plugins/SofaQtQuickGUI/data/python/templates/emptyDataEngine.py
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/python/templates/emptyDataEngine.py
@@ -1,0 +1,22 @@
+import Sofa.Core
+from Sofa.Helper import msg_info
+
+
+class %EmptyDataEngine%(Sofa.Core.DataEngine):
+    """ custom %EmptyDataEngine% component for SOFA """
+
+    def __init__(self, *args, **kwargs):
+        Sofa.Core.DataEngine.__init__(self, *args, **kwargs)
+        pass
+
+    def init(self):
+        pass
+
+    def update(self):
+        """
+        called anytime an output is accessed while the component
+        is dirty (input has changed)
+        """
+        msg_info('Not implemented yet')
+        pass
+    

--- a/applications-dev/plugins/SofaQtQuickGUI/data/python/templates/emptyForceField.py
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/python/templates/emptyForceField.py
@@ -1,0 +1,24 @@
+import Sofa.Core
+import numpy as np
+from Sofa.Helper import msg_info
+
+class %EmptyForcefield%(Sofa.Core.ForceField):
+    def __init__(self, *args, **kwargs):
+        Sofa.Core.ForceField.__init__(self, *args, **kwargs)
+        pass
+
+    def init(self):
+        pass
+
+    def addForce(self, m, forces, pos, vel):
+        msg_info('Not implemented yet')
+        pass
+
+    def addDForce(self, m, dforce, dx):
+        msg_info('Not implemented yet')
+        pass
+
+    def addKToMatrix(self, mparams, nNodes, nDofs):
+        msg_info('Not implemented yet')
+        pass
+

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaWidgets/PopupWindowCreateComponent.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaWidgets/PopupWindowCreateComponent.qml
@@ -63,17 +63,17 @@ Popup {
         Keys.forwardTo: [container]
         Keys.onPressed:
         {
-            if(event.key === Qt.Key_Return)
+            if (event.key === Qt.Key_Return)
             {
                 console.log("inputField Ret pressed")
                 inputField.text = SofaFactory.components[container.currentIndex]
             }
-            if(Qt.Key_Down === event.key)
+            if (Qt.Key_Down === event.key)
             {
                 container.incrementCurrentIndex()
                 text = null
             }
-            if(Qt.Key_Up === event.key)
+            if (Qt.Key_Up === event.key)
             {
                 container.decrementCurrentIndex()
                 text = null
@@ -83,7 +83,7 @@ Popup {
         onTextEdited:
         {
             SofaFactory.setFilter(text)
-            container.currentIndex=-1
+            container.currentIndex = -1
         }
 
         onAccepted:
@@ -107,8 +107,15 @@ Popup {
                     messageDialog.visible = true
                 }
             }
-            else{
-                messageCreateWidget.visible = true
+            else {
+                if (text.includes("(create) ")) {
+                    var val =text.split(" ")[1]
+                    console.log("create a python " + val)
+                    SofaApplication.currentProject.createPythonPrefab(val, sofaNode)
+                    searchBar.close()
+                } else {
+                    messageCreateWidget.visible = true
+                }
             }
             SofaFactory.setFilter("")
         }

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaFactory.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaFactory.cpp
@@ -75,7 +75,15 @@ void SofaFactory::setFilter(const QString& s)
 
 QStringList SofaFactory::getComponents()
 {
-    return m_filteredList ;
+    if (m_filteredList.size())
+        return m_filteredList;
+    else {
+        QStringList tmpList;
+        tmpList.push_back("(create) " + m_filter + "Controller");
+        tmpList.push_back("(create) " + m_filter + "DataEngine");
+        tmpList.push_back("(create) " + m_filter + "ForceField");
+        return tmpList;
+    }
 }
 
 QString SofaFactory::getComponentHelp(const QString& name)

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaProject.h
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaProject.h
@@ -73,6 +73,7 @@ public:
 
     /// These are for assets "creation"
     Q_INVOKABLE bool createPrefab(SofaBase* node);
+    Q_INVOKABLE bool createPythonPrefab(QString name, SofaBase* node);
     Q_INVOKABLE QString createProject(const QUrl& dir);
     Q_INVOKABLE bool createProjectTree(const QUrl& dir);
     Q_INVOKABLE QString importProject(const QUrl& archive);


### PR DESCRIPTION
- 3 empty templates (DataEngine, Controller, ForceField)

When trying to instantiate an unknown compoent in the scene graph (from PopupWindowCreateComponent), an empty template of one of those python component types is created:

- The template content is copied  into a string
- the %EmptyComponent% variable is located and replaced with the <ComponentName>
- The string is written in a file in %ProjectDir%/assets/scripts/<componentname>.py
- The module is loaded, the class instantiated & added to the scene graph