### PR TITLE
FIX: prefab Breaking

### DIFF
--- a/applications-dev/plugins/SofaQtQuickGUI/CMakeLists.txt
+++ b/applications-dev/plugins/SofaQtQuickGUI/CMakeLists.txt
@@ -300,6 +300,11 @@ set(HEADER_FILES ${HEADER_FILES}
     src/SofaQtQuickGUI/SofaParticleInteractor.inl
     )
 
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    # Sized deallocaion is not enabled by default under clang after c++14
+    set(CMAKE_CXX_FLAGS "-fsized-deallocation")
+endif ()
+
 add_library(${PROJECT_NAME} SHARED ${HEADER_FILES} ${MOC_FILES} ${SOURCE_FILES} ${QRC_FILES} ${RESOURCE_FILES} ${QML_FILES} ${CONFIG_FILES} ${PYTHON_FILES} ${EXTRA_FILES} ${ASSET_TEMPLATES})
 target_link_libraries(${PROJECT_NAME} PUBLIC ${SOFAPYTHON_LIBRARY} SofaOpenglVisual SofaGeneralLoader SofaLoader SofaSimulationGraph SofaGraphComponent SofaBoundaryCondition SofaComponentBase SofaMeshCollision
     Qt5::Core Qt5::Gui Qt5::Widgets Qt5::QuickControls2 Qt5::Qml Qt5::Quick Qt5::WebEngine Qt5::Charts stdc++fs QmlUI)

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Assets/PythonAsset.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Assets/PythonAsset.cpp
@@ -116,7 +116,7 @@ sofaqtquick::bindings::SofaNode* PythonAsset::create(sofaqtquick::bindings::Sofa
 
         if(isContextFree)
         {
-            root->addChild( resnode );
+            parent->addChild( new SofaNode(sofa::simulation::graph::DAGNode::SPtr(resnode)) );
         }
         resnode->init(sofa::core::ExecParams::defaultInstance());
         return new sofaqtquick::bindings::SofaNode(resnode, dynamic_cast<QObject*>(this));
@@ -124,7 +124,7 @@ sofaqtquick::bindings::SofaNode* PythonAsset::create(sofaqtquick::bindings::Sofa
     if(base->toBaseObject() != nullptr)
     {
         auto object = base->toBaseObject();
-        root->addObject( object );
+        parent->addObject( new SofaBaseObject(sofa::core::objectmodel::BaseObject::SPtr(object)) );
         object->init();
     }
     return parent;

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaNode.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaNode.cpp
@@ -39,6 +39,7 @@ using sofa::core::ExecParams;
 
 #include <SofaQtQuickGUI/DataHelper.h>
 #include <QMessageBox>
+#include <SofaPython3/Prefab.h>
 
 
 namespace sofaqtquick::bindings::_sofanode_
@@ -261,13 +262,21 @@ bool SofaNode::attemptToBreakPrefab()
     title += prefab->getName().c_str();
     if (QMessageBox::question(nullptr, title, tr("Are your sure that you want to proceed?")) == QMessageBox::StandardButton::Yes)
     {
-        prefab->removeData(prefab->findData("modulename"));
-        prefab->removeData(prefab->findData("prefabname"));
-        prefab->removeData(prefab->findData("modulepath"));
-        prefab->removeData(prefab->findData("lineno"));
-        prefab->removeData(prefab->findData("sourcecode"));
-        prefab->removeData(prefab->findData("docstring"));
-        prefab->removeData(prefab->findData("args"));
+        if (prefab->findData("modulename") != nullptr)
+            prefab->removeData(prefab->findData("modulename"));
+        if (prefab->findData("prefabname") != nullptr)
+            prefab->removeData(prefab->findData("prefabname"));
+        if (prefab->findData("modulepath") != nullptr)
+            prefab->removeData(prefab->findData("modulepath"));
+        if (prefab->findData("lineno") != nullptr)
+            prefab->removeData(prefab->findData("lineno"));
+        if (prefab->findData("sourcecode") != nullptr)
+            prefab->removeData(prefab->findData("sourcecode"));
+        if (prefab->findData("docstring") != nullptr)
+            prefab->removeData(prefab->findData("docstring"));
+        if (prefab->findData("args") != nullptr)
+            prefab->removeData(prefab->findData("args"));
+        dynamic_cast<sofapython3::Prefab*>(prefab)->breakPrefab();
         return true;
     }
     return false;


### PR DESCRIPTION
- Call SofaData->addObject / addChild instead of DAGNode->addObject/addChild in PythonAsset to disable prefab capabilities on ancestor nodes
- Checks for the existence of prefab data before trying to remove them

-> goes with this morning's SofaPython3 [PR #133](https://github.com/SofaDefrost/plugin.SofaPython3/pull/133)