### PR TITLE
FIX: flickable & DragNDrop from hierarchy to inspector

### DIFF
--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/CustomInspectorWidgets/BaseInspector.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/CustomInspectorWidgets/BaseInspector.qml
@@ -3,20 +3,13 @@ import SofaApplication 1.0
 import CustomInspectorWidgets 1.0
 
 CustomInspector {
-    property var component: SofaApplication.selectedComponent
-    onComponentChanged: {
-        if (!SofaApplication.selectedComponent)
-            return;
-        if (component !== SofaApplication.selectedComponent) {
-            component = SofaApplication.selectedComponent;
-            return;
-        }
 
+    function refresh() {
         var dataMap = {}
 //        console.error(SofaApplication.selectedComponent)
-        for (var idx in SofaApplication.selectedComponent.getDataFields()) {
-            var dataName = SofaApplication.selectedComponent.getDataFields()[idx]
-            var data = SofaApplication.selectedComponent.getData(dataName)
+        for (var idx in component.getDataFields()) {
+            var dataName = component.getDataFields()[idx]
+            var data = component.getData(dataName)
             if (data.properties.displayed || dataName === "gravity" || dataName === "bbox") {
                 if (data.properties.readOnly && showAll == false)
                     continue
@@ -40,6 +33,17 @@ CustomInspector {
             var linkName = SofaApplication.selectedComponent.getLinks()[idx]
             linkList.push(linkName)
         }
+    }
+
+    onComponentChanged: {
+        if (!SofaApplication.selectedComponent)
+            return;
+        if (component !== SofaApplication.selectedComponent) {
+            component = SofaApplication.selectedComponent;
+            return;
+        }
+
+        refresh()
     }
 
 }

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaBasics/SofaDataItem.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaBasics/SofaDataItem.qml
@@ -24,156 +24,157 @@ import SofaApplication 1.0
 import Sofa.Core.SofaData 1.0
 import SofaBasics 1.0
 
-Item {
-    id: self
+//Item {
+//    id: self
 
-    implicitWidth: gridlayout.implicitWidth
-    implicitHeight: dataWidget.implicitHeight
-    signal doubleClickedOnLabel;
+//    implicitWidth: gridlayout.implicitWidth
+//    implicitHeight: dataWidget.implicitHeight
+//    signal doubleClickedOnLabel;
 
-    property SofaData sofaData: null
+//    property SofaData sofaData: null
 
-    property var properties: sofaData.properties
-    property var widget: null
+//    property var properties: sofaData.properties
+//    property var widget: null
 
-    property int nameLabelWidth: -1
-    readonly property int nameLabelImplicitWidth: nameLabel.implicitWidth
+//    property int nameLabelWidth: -1
+//    readonly property int nameLabelImplicitWidth: nameLabel.implicitWidth
 
-    property bool readOnly: false
-    property bool showName: true
-    property bool showLinkButton: true
-    //property bool showTrackButton: true
-    //property alias track: trackButton.checked
-    property int refreshCounter: 0
+//    property bool readOnly: false
+//    property bool showName: true
+//    property bool showLinkButton: true
+//    //property bool showTrackButton: true
+//    //property alias track: trackButton.checked
+//    property int refreshCounter: 0
 
-    function updateData(newValue)
-    {
-        console.log("Update Data " + sofaData.name);
-        sofaData.value = newValue;
-    }
+//    function updateData(newValue)
+//    {
+//        console.log("Update Data " + sofaData.name);
+//        sofaData.value = newValue;
+//    }
 
-    GridLayout {
-        id: gridlayout
-        anchors.fill: parent
-        columns: 4
+//    GridLayout {
+//        id: gridlayout
+//        anchors.fill: parent
+//        columns: 4
 
-        columnSpacing: 1
-        rowSpacing: 1
+//        columnSpacing: 1
+//        rowSpacing: 1
 
-        Label {
-            id: nameLabel
-            Layout.preferredWidth: -1 === nameLabelWidth ? implicitWidth : nameLabelWidth
-            Layout.fillHeight: true
-            Layout.alignment: Qt.AlignTop
-            visible: self.showName
-            text: sofaData ? sofaData.name : ""
-            font.italic: true
-            color: properties.required && !properties.set ? "#bb0000" : "black"
-            clip: true
-            elide: Text.ElideRight
+////        Label {
+////            id: nameLabel
+////            Layout.preferredWidth: -1 === nameLabelWidth ? implicitWidth : nameLabelWidth
+////            Layout.fillHeight: true
+////            Layout.alignment: Qt.AlignTop
+////            visible: self.showName
+////            text: sofaData ? sofaData.name : ""
+////            font.italic: true
+////            color: properties.required && !properties.set ? "#bb0000" : "red"
+////            clip: true
+////            elide: Text.ElideRight
 
-            MouseArea {
-                id: dataLabelMouseArea
-                hoverEnabled: true
-                anchors.fill: parent
-                onDoubleClicked: self.doubleClickedOnLabel();
-            }
-            ToolTip {
-                text: sofaData? sofaData.name : ""
-                description: sofaData ? sofaData.help : ""
-                visible: dataLabelMouseArea.containsMouse
-            }
+////            MouseArea {
+////                id: dataLabelMouseArea
+////                hoverEnabled: true
+////                anchors.fill: parent
+////                onDoubleClicked: self.doubleClickedOnLabel();
+////            }
+////            ToolTip {
+////                text: sofaData? sofaData.name : ""
+////                description: sofaData ? sofaData.help : ""
+////                visible: dataLabelMouseArea.containsMouse
+////            }
 
-        }
+////        }
 
-        ColumnLayout
-        {
-            id: datawidget
-            Layout.fillWidth: true
-            Layout.fillHeight: true
-            Layout.alignment: Qt.AlignTop
-            spacing: 0
+//        ColumnLayout
+//        {
+//            id: datawidget
+//            Layout.fillWidth: true
+//            Layout.fillHeight: true
+//            Layout.alignment: Qt.AlignTop
+//            spacing: 0
 
-            RowLayout {
-                id: linkLayout
-                Layout.fillHeight: true
-                Layout.fillWidth: true
-                visible: sofaData && 0 !== sofaData.name.length && (linkButton.checked || (null !== sofaData.getParent() && !self.showLinkButton))
-                spacing: 0
-                SofaLinkItem {
-                    id: linkTextField
-                    sofaData: self.sofaData
-                    linkImage: linkButtonImage
-                    Component.onCompleted: self.implicitHeight = Qt.binding(function(){
-                        return linkLayout.visible ? linkTextField.implicitHeight : datawidget.implicitHeight
-                    })
-                    Layout.fillWidth: true
-                }
-            }
-        }
-
-        Item {
-            Layout.preferredWidth: 20
-            Layout.preferredHeight: Layout.preferredWidth
-            Layout.alignment: Qt.AlignTop
-            visible: self.showLinkButton
-
-            Button {
-                id: linkButton
-                anchors.fill: parent
-                anchors.margins: 3
-                checkable: true
-                checked: sofaData ? null !== sofaData.getParent() : false
-                onCheckedChanged: {
-                    linkTextField.forceActiveFocus()
-                }
-
-                activeFocusOnTab: false
-                ToolTip {
-                    text: "Link the data to another one."
-                }
-
-                Image {
-                    id: linkButtonImage
-                    anchors.fill: parent
-                    source: linkButton.checked ? "qrc:/icon/linkValid.png" : "qrc:/icon/link.png"
-                }
-            }
-        }
-
-//        CheckBox {
-//            id: trackButton
-//            visible: self.showTrackButton && 0 !== sofaData.name.length
-//            checked: false
-
-//            onClicked: self.updateObject();
-
-//            ToolTip {
-//                text: "Update the visualization of the data during simulation."
-//            }
-
-//            Timer {
-//                interval: 50
-//                repeat: true
-//                running: trackButton.checked
-
-//                onRunningChanged: self.updateObject();
-//                onTriggered: self.updateObject();
+//            RowLayout {
+//                id: linkLayout
+//                Layout.fillHeight: true
+//                Layout.fillWidth: true
+//                visible: sofaData && 0 !== sofaData.name.length && (linkButton.checked || (null !== sofaData.getParent() && !self.showLinkButton))
+//                spacing: 0
+//                SofaLinkItem {
+//                    id: linkTextField
+//                    sofaData: self.sofaData
+//                    linkImage: linkButtonImage
+//                    Component.onCompleted: self.implicitHeight = Qt.binding(function(){
+//                        return linkLayout.visible ? linkTextField.implicitHeight : datawidget.implicitHeight
+//                    })
+//                    Layout.fillWidth: true
+//                }
 //            }
 //        }
-    }
 
-    onSofaDataChanged:
-    {
-        console.log("value changed")
-        if(sofaData)
-        {
-            /// Returns the widget's properties associated with this SofaData
-            var component = SofaDataWidgetFactory.getWidgetForData(sofaData)
-            var o = component.createObject(datawidget, {"sofaData": sofaData,
-                                                "Layout.fillWidth":true})
-            self.implicitHeight = Qt.binding(function(){ return o.implicitHeight })
-            o.visible = Qt.binding(function() { return !linkButton.checked })
-        }
-    }
-}
+//        Item {
+//            Layout.preferredWidth: 20
+//            Layout.preferredHeight: Layout.preferredWidth
+//            Layout.alignment: Qt.AlignTop
+//            visible: self.showLinkButton
+
+//            Button {
+//                id: linkButton
+//                anchors.fill: parent
+//                anchors.margins: 3
+//                checkable: true
+//                checked: sofaData ? null !== sofaData.getParent() : false
+//                onCheckedChanged: {
+//                    linkTextField.forceActiveFocus()
+//                }
+
+//                activeFocusOnTab: false
+//                ToolTip {
+//                    text: "Link the data to another one."
+//                }
+
+//                Image {
+//                    id: linkButtonImage
+//                    anchors.fill: parent
+//                    source: linkButton.checked ? "qrc:/icon/linkValid.png" : "qrc:/icon/link.png"
+//                }
+//            }
+//        }
+
+////        CheckBox {
+////            id: trackButton
+////            visible: self.showTrackButton && 0 !== sofaData.name.length
+////            checked: false
+
+////            onClicked: self.updateObject();
+
+////            ToolTip {
+////                text: "Update the visualization of the data during simulation."
+////            }
+
+////            Timer {
+////                interval: 50
+////                repeat: true
+////                running: trackButton.checked
+
+////                onRunningChanged: self.updateObject();
+////                onTriggered: self.updateObject();
+////            }
+////        }
+//    }
+
+//    onSofaDataChanged:
+//    {
+//        console.log("value changed")
+//        if(sofaData)
+//        {
+//            /// Returns the widget's properties associated with this SofaData
+//            var component = SofaDataWidgetFactory.getWidgetForData(sofaData)
+//            var o = component.createObject(datawidget, {"sofaData": sofaData,
+//                                                "Layout.fillWidth":true})
+//            self.implicitHeight = Qt.binding(function(){ return o.implicitHeight })
+//            o.visible = Qt.binding(function() { return !linkButton.checked })
+//        }
+//    }
+//}
+Item {}

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/DynamicContainerView.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/DynamicContainerView.qml
@@ -14,10 +14,16 @@ ColumnLayout {
     Layout.fillWidth: true
     property SofaData sofaData
     property var value: 0
+
+    Component.onCompleted: {
+        value = sofaData.value
+    }
+
     Connections
     {
         target: root.sofaData
         onValueChanged: {
+            console.log("updating value for "+ root.sofaData.getName() + ": " + root.sofaData.value)
             root.value=root.sofaData.value
         }
     }

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/DynamicTableView.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/DynamicTableView.qml
@@ -195,7 +195,6 @@ ColumnLayout {
                 Layout.fillWidth: true
                 value: 0
                 position: cornerPositions[index == 0 ? 'Left' : 'Middle']
-
             }
         }
         Button {

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaViews/Hierarchy.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaViews/Hierarchy.qml
@@ -583,9 +583,6 @@ Rectangle {
                 z: 1
             }
 
-
-            //Drag.active: mouseArea.drag.active
-            //Drag.dragType: Drag.Automatic
             SofaNodeMenu
             {
                 id: nodeMenu

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaViews/Inspector.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaViews/Inspector.qml
@@ -43,26 +43,6 @@ Item {
         color: SofaApplication.style.contentBackgroundColor
         anchors.fill: parent
         visible: selectedAsset === null
-        DropArea {
-            id: dropArea
-            anchors.fill: parent
-            onDropped: {
-                /// Drop of a SofaBase form the hierachy. This indicate that we want
-                /// to automatically connect all the data fields with similar names.
-                if (drag.source.origin === "Hierarchy") {
-                    var droppedItem = drag.source.item 
-                    /// Ecmascript6.0 'for..of' is valid, don't trust qtcreator there is an error
-                    for (var fname of droppedItem.getDataFields())
-                    {
-                        var data = SofaApplication.selectedComponent.findData(fname);
-                        if (data !== null && data.isAutoLink())
-                        {
-                            data.setParent(droppedItem.getData(fname))
-                        }
-                    }
-                }
-            }
-        }
 
         ColumnLayout {
             anchors.fill: parent
@@ -73,6 +53,30 @@ Item {
                 Layout.fillWidth: true
                 Layout.rightMargin: 10
                 Layout.preferredHeight: 20
+
+                DropArea {
+                    id: dropArea
+                    anchors.fill: parent
+                    onDropped: {
+                        console.log("DROPPPED YAY")
+                        /// Drop of a SofaBase form the hierachy. This indicate that we want
+                        /// to automatically connect all the data fields with similar names.
+                        if (drag.source.origin === "Hierarchy") {
+                            var droppedItem = drag.source.item
+                            /// Ecmascript6.0 'for..of' is valid, don't trust qtcreator there is an error
+                            for (var fname of droppedItem.getDataFields())
+                            {
+                                var data = SofaApplication.selectedComponent.findData(fname);
+                                if (data !== null && data.isAutoLink())
+                                {
+                                    console.log("DROPPPED")
+                                    data.setValue(droppedItem.getData(fname).getValue())
+                                    data.setParent(droppedItem.getData(fname))
+                                }
+                            }
+                        }
+                    }
+                }
 
                 Text {
                     id: detailsArea
@@ -100,6 +104,8 @@ Item {
                 Layout.fillWidth: true
                 Layout.leftMargin: 5
                 clip: true
+                flickableDirection: Flickable.VerticalFlick
+                boundsMovement: Flickable.StopAtBounds
                 ScrollBar.horizontal: ScrollBar {
                     policy: ScrollBar.AlwaysOff
                 }

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaProject.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaProject.cpp
@@ -526,7 +526,7 @@ bool SofaProject::createPythonPrefab(QString name, SofaBase* node)
 void SofaProject::saveScene(const QString filepath, SofaNode* node)
 {
     QFile::copy(filepath, filepath + ".backup");
-    sofapython3::PythonEnvironment::executePython([this, filepath, node]()
+    sofapython3::PythonEnvironment::executePython([filepath, node]()
     {
         std::string ppath = filepath.toStdString();
         py::module SofaQtQuick = py::module::import("SofaQtQuick");


### PR DESCRIPTION
DragNDrop working in Inspector now:

- Drop on Inspector's header to link all matching datafields
- Drop on datafield's label for single data linking (with matching name)

TODO:
- When dropping on inspector header, inspector not refreshing its datafields properly
- Figure out a way to link non-matching datafield names (e.g. output_position -> position)
