### PR TITLE
FIX: Manipulators

### DIFF
--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/CustomInspectorWidgets/BaseInspector.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/CustomInspectorWidgets/BaseInspector.qml
@@ -6,7 +6,6 @@ CustomInspector {
 
     function refresh() {
         var dataMap = {}
-//        console.error(SofaApplication.selectedComponent)
         for (var idx in component.getDataFields()) {
             var dataName = component.getDataFields()[idx]
             var data = component.getData(dataName)
@@ -21,10 +20,6 @@ CustomInspector {
                 if (dataMap[group] === undefined)
                     dataMap[group] = []
                 dataMap[group].push(dataName)
-            }
-            else
-            {
-//                console.log(dataName)
             }
         }
         dataDict = dataMap

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaInteractors/UserInteractor_EditMode.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaInteractors/UserInteractor_EditMode.qml
@@ -161,11 +161,11 @@ UserInteractor {
                         currentManipulator = SofaApplication.getManipulators()[i];
                     }
                 }
-                if(particle.manipulator || currentManipulator) {
-                    console.log("selected manipulator: " + particle.manipulator.name)
-                    currentManipulator = particle.manipulator
-                    SofaApplication.getManipulators()[i].particleIndex = particle.particleIndex
-                    SofaApplication.getManipulators()[i].mousePressed(Qt.point(mouse.x, mouse.y), sofaViewer);
+                if(currentManipulator) {
+                    console.log("selected manipulator: " + currentManipulator.name)
+//                    currentManipulator = particle.manipulator
+//                    SofaApplication.getManipulators()[i].particleIndex = particle.particleIndex
+                    currentManipulator.mousePressed(Qt.point(mouse.x, mouse.y), sofaViewer);
                     if (currentManipulator.displayText !== "")
                     {
                         label = Qt.createQmlObject('import QtQuick.Controls 2.0;
@@ -191,9 +191,9 @@ UserInteractor {
                         currentManipulator.mouseMoved(m, sofaViewer)
                     })
                 }
-                return
+//                return
             }
-            currentManipulator = null
+//            currentManipulator = null
             var object = sofaViewer.pickObject(Qt.point(mouse.x, mouse.y));
             if (object && object.sofaComponent)
                 console.log("object found")

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaInteractors/UserInteractor_EditMode.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaInteractors/UserInteractor_EditMode.qml
@@ -153,11 +153,19 @@ UserInteractor {
                     console.error("SelectedComponent: " + particle.sofaComponent)
                     SofaApplication.selectedComponent = particle.sofaComponent;
                 }
-                if(particle.manipulator) {
+                currentManipulator = null
+                for (var i = 0 ; i < SofaApplication.getManipulators().length ; ++i) {
+                    SofaApplication.getManipulators()[i].isEditMode = true
+                    SofaApplication.getManipulators()[i].particleIndex = particle.particleIndex
+                    if (SofaApplication.getManipulators()[i].enabled) {
+                        currentManipulator = SofaApplication.getManipulators()[i];
+                    }
+                }
+                if(particle.manipulator || currentManipulator) {
                     console.log("selected manipulator: " + particle.manipulator.name)
                     currentManipulator = particle.manipulator
-                    manipulator.particleIndex = particle.particleIndex
-                    manipulator.mousePressed(Qt.point(mouse.x, mouse.y), sofaViewer);
+                    SofaApplication.getManipulators()[i].particleIndex = particle.particleIndex
+                    SofaApplication.getManipulators()[i].mousePressed(Qt.point(mouse.x, mouse.y), sofaViewer);
                     if (currentManipulator.displayText !== "")
                     {
                         label = Qt.createQmlObject('import QtQuick.Controls 2.0;

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaInteractors/UserInteractor_ObjectMode.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaInteractors/UserInteractor_ObjectMode.qml
@@ -178,7 +178,7 @@ UserInteractor {
                                                            label.destroy();
                                                    }
                                                 }', sofaViewer, 'label');
-                    label.text = Qt.binding(function(){ return currentManipulator.displayText });
+                    label.text = Qt.binding(function(){ return currentManipulator ? currentManipulator.displayText : "" });
                     label.x = Qt.binding(function(){ return mouse.x + 15});
                     label.y = Qt.binding(function(){ return mouse.y - 15});
                 }

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaWidgets/EditModeManipulators.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaWidgets/EditModeManipulators.qml
@@ -38,7 +38,6 @@ Column {
         manipulator: SofaApplication.getManipulator(manipulatorName)
 
         onOptionChanged: {
-            print ("OPTION")
             manipulator = setManipulator(manipulatorName)
         }
 

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaWidgets/ObjectModeManipulators.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaWidgets/ObjectModeManipulators.qml
@@ -24,7 +24,6 @@ Column {
             if (!SofaApplication.getManipulators()[i].persistent &&
                     (m && m.name !== SofaApplication.getManipulators()[i].name)) {
                 SofaApplication.getManipulators()[i].enabled = false
-                print("disabling " + SofaApplication.getManipulators()[i].name)
             }
         }
         m.enabled = true
@@ -37,7 +36,6 @@ Column {
         manipulator: SofaApplication.getManipulator(manipulatorName)
 
         onOptionChanged: {
-            print ("OPTION")
             manipulator = setManipulator(manipulatorName)
         }
 

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Manipulators/Rotate_Manipulator.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Manipulators/Rotate_Manipulator.cpp
@@ -5,6 +5,7 @@
 #include <SofaQtQuickGUI/SofaBaseApplication.h>
 #include <SofaQtQuickGUI/Bindings/SofaBase.h>
 #include <SofaQtQuickGUI/Helper/sofaqtconversions.h>
+#include <sofa/core/visual/VisualParams.h>
 #include <qmath.h>
 
 using namespace sofa::defaulttype;
@@ -19,7 +20,7 @@ Rotate_Manipulator::Rotate_Manipulator(QObject* parent)
     m_index = -1;
 }
 
-void Rotate_Manipulator::drawXAxis(const QVector3D& pos)
+void Rotate_Manipulator::drawXAxis(const QVector3D& pos, sofa::core::visual::DrawToolGL& drawtools)
 {
     QVector4D axisAngle(0, 1, 0, 90);
     glTranslatef(pos.x(), pos.y(), pos.z());
@@ -31,7 +32,7 @@ void Rotate_Manipulator::drawXAxis(const QVector3D& pos)
     glTranslatef(-pos.x(), -pos.y(), -pos.z());
 }
 
-void Rotate_Manipulator::drawYAxis(const QVector3D& pos)
+void Rotate_Manipulator::drawYAxis(const QVector3D& pos, sofa::core::visual::DrawToolGL& drawtools)
 {
     QVector4D axisAngle(1, 0, 0, -90);
     glTranslatef(pos.x(), pos.y(), pos.z());
@@ -43,7 +44,7 @@ void Rotate_Manipulator::drawYAxis(const QVector3D& pos)
     glTranslatef(-pos.x(), -pos.y(), -pos.z());
 }
 
-void Rotate_Manipulator::drawZAxis(const QVector3D& pos)
+void Rotate_Manipulator::drawZAxis(const QVector3D& pos, sofa::core::visual::DrawToolGL& drawtools)
 {
     QVector4D axisAngle(1, 0, 0, 0);
     glTranslatef(pos.x(), pos.y(), pos.z());
@@ -56,7 +57,7 @@ void Rotate_Manipulator::drawZAxis(const QVector3D& pos)
 }
 
 
-void Rotate_Manipulator::drawCamAxis(const QVector3D& pos)
+void Rotate_Manipulator::drawCamAxis(const QVector3D& pos, sofa::core::visual::DrawToolGL& drawtools)
 {
     QVector4D axisAngle = toAxisAngle(cam->orientation());
     glTranslatef(pos.x(), pos.y(), pos.z());
@@ -214,6 +215,10 @@ void Rotate_Manipulator::internalDraw(const SofaViewer& viewer, int pickIndex, b
     cam = viewer.camera();
     if (!cam) return;
 
+    sofa::core::visual::DrawToolGL& dt = *dynamic_cast<sofa::core::visual::DrawToolGL*>(
+                viewer.getVisualParams()->drawTool());
+
+
     QVector3D center;
     if (!Translate_Manipulator::GetValue(center, m_isEditMode, m_particleIndex)) return;
     if (m_index == -1)
@@ -264,25 +269,25 @@ void Rotate_Manipulator::internalDraw(const SofaViewer& viewer, int pickIndex, b
 
     if (pickIndex == -1 || pickIndex == 1)
     {
-        drawXAxis(center);
+        drawXAxis(center, dt);
         drawDottedLine(toVec3d(center), toVec3d(mX), 3, 0xAAAA, lineThickness, white);
     }
 
     if (pickIndex == -1 || pickIndex == 2)
     {
-        drawYAxis(center);
+        drawYAxis(center, dt);
         drawDottedLine(toVec3d(center), toVec3d(mY), 3, 0xAAAA, lineThickness, white);
     }
 
     if (pickIndex == -1 || pickIndex == 3)
     {
-        drawZAxis(center);
+        drawZAxis(center, dt);
         drawDottedLine(toVec3d(center), toVec3d(mZ), 3, 0xAAAA, lineThickness, white);
     }
 
     if (pickIndex == -1 || pickIndex == 4)
     {
-        drawCamAxis(center);
+        drawCamAxis(center, dt);
         drawDottedLine(toVec3d(center), toVec3d(mCam), 3, 0xAAAA, lineThickness, white);
     }
 

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Manipulators/Rotate_Manipulator.h
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Manipulators/Rotate_Manipulator.h
@@ -40,11 +40,11 @@ private:
 
 
 private:
-    void drawXAxis(const QVector3D& pos);
-    void drawYAxis(const QVector3D& pos);
-    void drawZAxis(const QVector3D& pos);
-    void drawCamAxis(const QVector3D& pos);
-    void drawTrackballAxis(const QVector3D& pos);
+    void drawXAxis(const QVector3D& pos, sofa::core::visual::DrawToolGL& dt);
+    void drawYAxis(const QVector3D& pos, sofa::core::visual::DrawToolGL& dt);
+    void drawZAxis(const QVector3D& pos, sofa::core::visual::DrawToolGL& dt);
+    void drawCamAxis(const QVector3D& pos, sofa::core::visual::DrawToolGL& dt);
+    void drawTrackballAxis(const QVector3D& pos, sofa::core::visual::DrawToolGL& dt);
 
 
     float radius;
@@ -53,8 +53,6 @@ private:
     float width;
     float height;
 
-
-    sofa::core::visual::DrawToolGL drawtools;
     bindings::SofaBase* obj;
     sofa::Data<sofa::defaulttype::Vec3d>* data;
     Camera* cam;

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Manipulators/Translate_Manipulator.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Manipulators/Translate_Manipulator.cpp
@@ -4,6 +4,7 @@
 #include <SofaQtQuickGUI/SofaBaseApplication.h>
 #include <SofaQtQuickGUI/Bindings/SofaBase.h>
 #include <SofaQtQuickGUI/Helper/sofaqtconversions.h>
+#include <sofa/core/visual/VisualParams.h>
 
 using namespace sofa::defaulttype;
 namespace sofaqtquick
@@ -16,7 +17,7 @@ Translate_Manipulator::Translate_Manipulator(QObject* parent)
     m_index = -1;
 }
 
-void Translate_Manipulator::drawXArrow(const Vec3d& pos)
+void Translate_Manipulator::drawXArrow(const Vec3d& pos, sofa::core::visual::DrawToolGL& drawtools)
 {
     Vec3d p1 = pos + Vec3d(squareWidth, 0.0, 0.0);
     Vec3d p2 = p1 + Vec3d(arrowLength, 0.0, 0.0);
@@ -35,7 +36,7 @@ void Translate_Manipulator::drawXArrow(const Vec3d& pos)
     drawtools.drawArrow(p1, p2, radius, float(arrowLength) / 5.0f, radius*5.0f, m_index == 0 ? highlightred : red, 16);
 }
 
-void Translate_Manipulator::drawYArrow(const Vec3d& pos)
+void Translate_Manipulator::drawYArrow(const Vec3d& pos, sofa::core::visual::DrawToolGL& drawtools)
 {
     Vec3d p1 = pos + Vec3d(0.0, squareWidth, 0.0);
     Vec3d p2 = p1 + Vec3d(0.0, arrowLength, 0.0);
@@ -54,7 +55,7 @@ void Translate_Manipulator::drawYArrow(const Vec3d& pos)
     drawtools.drawArrow(p1, p2, radius, float(arrowLength) / 5.0f, radius*5.0f, m_index == 1 ? highlightgreen : green, 16);
 }
 
-void Translate_Manipulator::drawZArrow(const Vec3d& pos)
+void Translate_Manipulator::drawZArrow(const Vec3d& pos, sofa::core::visual::DrawToolGL& drawtools)
 {
     Vec3d p1 = pos + Vec3d(0.0, 0.0, squareWidth);
     Vec3d p2 = p1 + Vec3d(0.0, 0.0, arrowLength);
@@ -73,7 +74,7 @@ void Translate_Manipulator::drawZArrow(const Vec3d& pos)
     drawtools.drawArrow(p1, p2, radius, float(arrowLength) / 5.0f, radius*5.0f, m_index == 2 ? highlightblue : blue, 16);
 }
 
-void Translate_Manipulator::drawXYPlane(const Vec3d& pos)
+void Translate_Manipulator::drawXYPlane(const Vec3d& pos, sofa::core::visual::DrawToolGL& drawtools)
 {
     if (lightblue.w() != 1.0f)
     {
@@ -90,7 +91,7 @@ void Translate_Manipulator::drawXYPlane(const Vec3d& pos)
     drawtools.drawLineLoop({a,b,c,d}, lineThickness, blue);
 }
 
-void Translate_Manipulator::drawYZPlane(const Vec3d& pos)
+void Translate_Manipulator::drawYZPlane(const Vec3d& pos, sofa::core::visual::DrawToolGL& drawtools)
 {
     if (lightred.w() != 1.0f)
     {
@@ -108,7 +109,7 @@ void Translate_Manipulator::drawYZPlane(const Vec3d& pos)
     drawtools.drawLineLoop({a,b,c,d}, lineThickness, red);
 }
 
-void Translate_Manipulator::drawZXPlane(const Vec3d& pos)
+void Translate_Manipulator::drawZXPlane(const Vec3d& pos, sofa::core::visual::DrawToolGL& drawtools)
 {
     if (lightgreen.w() != 1.0f)
     {
@@ -126,7 +127,7 @@ void Translate_Manipulator::drawZXPlane(const Vec3d& pos)
     drawtools.drawLineLoop({a,b,c,d}, lineThickness, green);
 }
 
-void Translate_Manipulator::drawCamPlane(const Vec3d& pos, bool isPicking)
+void Translate_Manipulator::drawCamPlane(const Vec3d& pos, bool isPicking, sofa::core::visual::DrawToolGL& drawtools)
 {
     Vec3d up(double(cam->up().x()),
              double(cam->up().y()),
@@ -236,6 +237,9 @@ void Translate_Manipulator::internalDraw(const SofaViewer& viewer, int pickIndex
     cam = viewer.camera();
     if (!cam) return;
 
+    sofa::core::visual::DrawToolGL& dt = *dynamic_cast<sofa::core::visual::DrawToolGL*>(
+                viewer.getVisualParams()->drawTool());
+
 
     glEnable(GL_MULTISAMPLE_ARB);
     glDisable(GL_DEPTH_TEST);
@@ -269,27 +273,27 @@ void Translate_Manipulator::internalDraw(const SofaViewer& viewer, int pickIndex
     yellow = Vec4f(0.957f, 0.65f, 0.0f, 1.0f);
 
     if (pickIndex == -1 || pickIndex == 0)
-        drawXArrow(helper::toVec3d(pos));
+        drawXArrow(helper::toVec3d(pos), dt);
 
     if (pickIndex == -1 || pickIndex == 1)
-        drawYArrow(helper::toVec3d(pos));
+        drawYArrow(helper::toVec3d(pos), dt);
 
     if (pickIndex == -1 || pickIndex == 2)
-        drawZArrow(helper::toVec3d(pos));
+        drawZArrow(helper::toVec3d(pos), dt);
 
     if (pickIndex == -1 || pickIndex == 3)
-        drawXYPlane(helper::toVec3d(pos));
+        drawXYPlane(helper::toVec3d(pos), dt);
 
     if (pickIndex == -1 || pickIndex == 4)
-        drawYZPlane(helper::toVec3d(pos));
+        drawYZPlane(helper::toVec3d(pos), dt);
 
     if (pickIndex == -1 || pickIndex == 5)
-        drawZXPlane(helper::toVec3d(pos));
+        drawZXPlane(helper::toVec3d(pos), dt);
 
     glDisable(GL_BLEND);
 
     if (pickIndex == -1 || pickIndex == 6)
-        drawCamPlane(helper::toVec3d(pos), isPicking);
+        drawCamPlane(helper::toVec3d(pos), isPicking, dt);
 
     glEnable(GL_DEPTH_TEST);
     glDisable(GL_MULTISAMPLE_ARB);
@@ -302,8 +306,7 @@ void Translate_Manipulator::mouseMoved(const QPointF& mouse, SofaViewer* viewer)
 
     QVector3D pos;
     if (!getValue(pos)) return;
-    std::cout << pos.x() << " " << pos.y()  << " " << pos.z() << std::endl;
-    std::cout << m_index << std::endl;
+
     QVector3D translated;
     switch (m_index)
     {

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Manipulators/Translate_Manipulator.h
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Manipulators/Translate_Manipulator.h
@@ -29,13 +29,13 @@ public:
     void setValue(const QVector3D&);
 
 private:
-    void drawXArrow(const sofa::defaulttype::Vec3d& pos);
-    void drawYArrow(const sofa::defaulttype::Vec3d& pos);
-    void drawZArrow(const sofa::defaulttype::Vec3d& pos);
-    void drawXYPlane(const sofa::defaulttype::Vec3d& pos);
-    void drawYZPlane(const sofa::defaulttype::Vec3d& pos);
-    void drawZXPlane(const sofa::defaulttype::Vec3d& pos);
-    void drawCamPlane(const sofa::defaulttype::Vec3d& pos, bool isPicking);
+    void drawXArrow(const sofa::defaulttype::Vec3d& pos, sofa::core::visual::DrawToolGL&);
+    void drawYArrow(const sofa::defaulttype::Vec3d& pos, sofa::core::visual::DrawToolGL&);
+    void drawZArrow(const sofa::defaulttype::Vec3d& pos, sofa::core::visual::DrawToolGL&);
+    void drawXYPlane(const sofa::defaulttype::Vec3d& pos, sofa::core::visual::DrawToolGL&);
+    void drawYZPlane(const sofa::defaulttype::Vec3d& pos, sofa::core::visual::DrawToolGL&);
+    void drawZXPlane(const sofa::defaulttype::Vec3d& pos, sofa::core::visual::DrawToolGL&);
+    void drawCamPlane(const sofa::defaulttype::Vec3d& pos, bool isPicking, sofa::core::visual::DrawToolGL&);
 
     float radius;
     float lineThickness;
@@ -43,7 +43,6 @@ private:
     double arrowLength;
     double squareWidth;
 
-    sofa::core::visual::DrawToolGL drawtools;
     bindings::SofaBase* obj;
     Camera* cam;
 

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Manipulators/Viewpoint_Manipulator.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Manipulators/Viewpoint_Manipulator.cpp
@@ -1,5 +1,6 @@
 #include "Viewpoint_Manipulator.h"
 #include <SofaQtQuickGUI/Helper/sofaqtconversions.h>
+#include <sofa/core/visual/VisualParams.h>
 #include <qmath.h>
 
 namespace sofaqtquick
@@ -18,11 +19,14 @@ Viewpoint_Manipulator::Viewpoint_Manipulator(QObject* parent)
 
 void Viewpoint_Manipulator::internalDraw(const SofaViewer &viewer, int pickIndex, bool isPicking)
 {
-    sofa::core::visual::DrawToolGL dt;
     Camera* cam = viewer.camera();
     if (!cam) return;
 
     cam->setOrthographic(true);
+
+    sofa::core::visual::DrawToolGL& dt = *dynamic_cast<sofa::core::visual::DrawToolGL*>(
+                viewer.getVisualParams()->drawTool());
+
     glMatrixMode(GL_PROJECTION);
     glPushMatrix();
     glLoadMatrixf(cam->projection().constData());
@@ -35,6 +39,9 @@ void Viewpoint_Manipulator::internalDraw(const SofaViewer &viewer, int pickIndex
     glDisable(GL_LIGHTING);
     glEnable(GL_DEPTH_TEST);
 
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
     double distanceToPoint = double(viewer.projectOnPlane(QPointF(viewer.width()/2, viewer.height()/2),
                                                   cam->target(), cam->direction()).distanceToPoint(cam->eye()));
 
@@ -44,133 +51,9 @@ void Viewpoint_Manipulator::internalDraw(const SofaViewer &viewer, int pickIndex
 
 
     Vec3d p = helper::toVec3d(viewer.mapToWorld(QPointF(viewer.width() - 50,50), cam->zNear()));
-/*
-//    if (!isPicking || pickIndex == 0)
-//    {
-//        if (!isPicking)
-//        {
-//            // if we removed the alpha it's for picking
-//            glEnable(GL_BLEND);
-//            glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-//        }
 
-//        // Draw front plane
-//        a = p + Vec3d(-squareWidth/2, -squareWidth / 2, squareWidth / 2);
-//        b = a + Vec3d(squareWidth, 0.0, 0.0);
-//        c = b + Vec3d(0.0, squareWidth, 0.0);
-//        d = c + Vec3d(-squareWidth, 0.0, 0.0);
-//        dt.drawQuad(a,b,c,d, Vec3d(0,0,1), Vec4f(1.0f,1.0f,1.0f,1.0f) );
-//        dt.drawLineLoop({a,b,c,d}, 0.5f, Vec4f(.0f,1.0f,1.0f,1.0));
-////        glLineWidth(2.0);
-////        dt.drawLine(p, p - Vec3d(0,0, -squareWidth/2), Vec4f(.0f,.0f,1.0f,1.0f));
-////        glLineWidth(1.0);
-////        dt.drawSphere(p - Vec3d(0,0, -squareWidth/2), squareWidth / 7.0, Vec4f(.0f,.0f,1.0f,1.0f));
-//    }
-
-//    if (!isPicking || pickIndex == 1)
-//    {
-//        if (!isPicking)
-//        {
-//            // if we removed the alpha it's for picking
-//            glEnable(GL_BLEND);
-//            glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-//        }
-
-//        // Draw back plane
-//        a = p + Vec3d(-squareWidth / 2, -squareWidth / 2, -squareWidth / 2);
-//        b = a + Vec3d(squareWidth, 0.0, 0.0);
-//        c = b + Vec3d(0.0, squareWidth, 0.0);
-//        d = c + Vec3d(-squareWidth, 0.0, 0.0);
-//        dt.drawQuad(a,b,c,d, Vec3d(0,0,1), Vec4f(1.0,1.0,1.0,1.0f) );
-//        dt.drawLineLoop({a,b,c,d}, 0.5f, Vec4f(.0,1.0,1.0,1.0));
-////        dt.drawSphere(p - Vec3d(0,0, squareWidth/2), squareWidth / 7.0, Vec4f(.3f,.3f,.8f,1.0f));
-//    }
-
-//    if (!isPicking || pickIndex == 2)
-//    {
-//        if (!isPicking)
-//        {
-//            // if we removed the alpha it's for picking
-//            glEnable(GL_BLEND);
-//            glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-//        }
-
-//        // Draw right plane
-//        a = p + Vec3d(squareWidth / 2, -squareWidth / 2.0, -squareWidth / 2);
-//        b = a + Vec3d(0.0, 0.0, squareWidth);
-//        c = b + Vec3d(0.0, squareWidth, 0.0);
-//        d = c + Vec3d(0.0, 0.0, -squareWidth);
-//        dt.drawQuad(a,b,c,d, Vec3d(0,0,1), Vec4f(1.0,1.0,1.0,1.0f) );
-//        dt.drawLineLoop({a,b,c,d}, 0.5f, Vec4f(.0,1.0,1.0,1.0));
-////        glLineWidth(2.0);
-////        dt.drawLine(p, p - Vec3d(-squareWidth/2,0, 0), Vec4f(1.0f,.0f,.0f,1.0f));
-////        glLineWidth(1.0);
-////        dt.drawSphere(p - Vec3d(-squareWidth/2,0, 0), squareWidth / 7.0, Vec4f(1.0f,.0f,.0f,1.0f));
-//    }
-
-//    if (!isPicking || pickIndex == 3)
-//    {
-//        if (!isPicking)
-//        {
-//            // if we removed the alpha it's for picking
-//            glEnable(GL_BLEND);
-//            glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-//        }
-
-
-//        // Draw left plane
-//        a = p + Vec3d(-squareWidth / 2.0, -squareWidth / 2.0, -squareWidth /2);
-//        b = a + Vec3d(0.0, 0.0, squareWidth);
-//        c = b + Vec3d(0.0, squareWidth, 0.0);
-//        d = c + Vec3d(0.0, 0.0, -squareWidth);
-//        dt.drawQuad(a,b,c,d, Vec3d(0,0,1), Vec4f(1.0,1.0,1.0,1.0f) );
-//        dt.drawLineLoop({a,b,c,d}, 0.5f, Vec4f(.0,1.0,1.0,1.0));
-////        dt.drawSphere(p - Vec3d(squareWidth/2,0, 0), squareWidth / 7.0, Vec4f(.8f,.3f,.3f,1.0f));
-//    }
-
-//    if (!isPicking || pickIndex == 4)
-//    {
-//        if (!isPicking)
-//        {
-//            // if we removed the alpha it's for picking
-//            glEnable(GL_BLEND);
-//            glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-//        }
-
-//        // Draw top plane
-//        a = p + Vec3d(-squareWidth / 2.0, squareWidth / 2, -squareWidth / 2);
-//        b = a + Vec3d(0.0, 0.0, squareWidth);
-//        c = b + Vec3d(squareWidth, 0.0, 0.0);
-//        d = c + Vec3d(0.0, 0.0, -squareWidth);
-//        dt.drawQuad(a,b,c,d, Vec3d(0,0,1), Vec4f(1.0,1.0,1.0,1.0f) );
-//        dt.drawLineLoop({a,b,c,d}, 0.5f, Vec4f(.0,1.0,1.0,1.0));
-////        glLineWidth(2.0);
-////        dt.drawLine(p, p - Vec3d(0,-squareWidth/2, 0), Vec4f(0.0f,1.0f,.0f,1.0f));
-////        glLineWidth(1.0);
-////        dt.drawSphere(p - Vec3d(0,-squareWidth/2, 0), squareWidth / 7.0, Vec4f(0.0f,1.0f,.0f,1.0f));
-//    }
-
-//    if (!isPicking || pickIndex == 5)
-//    {
-//        if (!isPicking)
-//        {
-//            // if we removed the alpha it's for picking
-//            glEnable(GL_BLEND);
-//            glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-//        }
-
-//        // Draw bottom plane
-//        a = p + Vec3d(squareWidth / 2, -squareWidth / 2.0, -squareWidth / 2);
-//        b = a + Vec3d(0.0, 0.0, squareWidth);
-//        c = b + Vec3d(-squareWidth, 0.0, 0.0);
-//        d = c + Vec3d(0.0, 0.0, -squareWidth);
-//        dt.drawQuad(a,b,c,d, Vec3d(0,0,1), Vec4f(1.0,1.0,1.0,1.0f) );
-//        dt.drawLineLoop({a,b,c,d}, 0.5f, Vec4f(.0,1.0,1.0,1.0));
-////        dt.drawSphere(p - Vec3d(0,squareWidth/2, 0), squareWidth / 7.0, Vec4f(.3f,.8f,.3f,1.0f));
-//    }
-*/
-//    glDisable(GL_DEPTH_TEST);
-    dt.drawSphere(p, float(squareWidth * 0.8), Vec4f(1.0f, 1.0f, 1.0f, .03f));
+    if (!isPicking)
+        dt.drawSphere(p, float(squareWidth * 0.8), Vec4f(1.0f, 1.0f, 1.0f, .03f));
 
     if (!isPicking || pickIndex == 0)
     {
@@ -216,6 +99,7 @@ void Viewpoint_Manipulator::internalDraw(const SofaViewer &viewer, int pickIndex
 
 
     glColor4d(1,1,1,1);
+
     cam->setOrthographic(false);
 
     glMatrixMode(GL_PROJECTION);
@@ -248,26 +132,9 @@ void Viewpoint_Manipulator::mouseClicked(const QPointF& /*mouse*/, SofaViewer *v
     case 5: // move to BOTTOM plane
         cam->viewFromBottom();
         break;
-//    case 6: // move to BACK plane
-//        shift = viewer->projectOnPlane(mouse, pos, cam->direction()) - pos;
-//        break;
     };
 }
 
-//void Viewpoint_Manipulator::mouseMoved(const QPointF &mouse, SofaViewer *viewer)
-//{
-
-//}
-
-//void Viewpoint_Manipulator::mousePressed(const QPointF &mouse, SofaViewer *viewer)
-//{
-
-//}
-
-//void Viewpoint_Manipulator::mouseReleased(const QPointF &mouse, SofaViewer *viewer)
-//{
-
-//}
 
 QString Viewpoint_Manipulator::getDisplayText() const
 {

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Manipulators/Viewpoint_Manipulator.h
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Manipulators/Viewpoint_Manipulator.h
@@ -16,9 +16,6 @@ public:
     Viewpoint_Manipulator(QObject* parent = nullptr);
 
     virtual void internalDraw(const SofaViewer& viewer, int pickIndex, bool isPicking = false) override;
-//    virtual void mouseMoved(const QPointF& mouse, SofaViewer* viewer) override;
-//    virtual void mousePressed(const QPointF& mouse, SofaViewer* viewer) override;
-//    virtual void mouseReleased(const QPointF& mouse, SofaViewer* viewer) override;
     virtual void mouseClicked(const QPointF& mouse, SofaViewer* viewer) override;
     virtual QString getDisplayText() const override;
 

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaBaseScene.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaBaseScene.cpp
@@ -190,6 +190,7 @@ SofaBaseScene::SofaBaseScene(QObject *parent) : QObject(parent),
 
     sofa::helper::system::PluginManager::getInstance().init();
 
+    myManipulators.push_back(new Viewpoint_Manipulator(this));
     // connections
     connect(this, &SofaBaseScene::sourceChanged, this, &SofaBaseScene::open);
     connect(this, &SofaBaseScene::animateChanged, myStepTimer, [&](bool newAnimate) {newAnimate ? myStepTimer->start() : myStepTimer->stop();});

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaViewer.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaViewer.cpp
@@ -948,7 +948,6 @@ Selectable* SofaViewer::pickObject(const QPointF& ssPoint, const QStringList& ta
                     {
                         if (manipulator->enabled())
                         {
-                            std::cout << "MANIPULATOR " << manipulator->getName().toStdString() << " is enabled" << std::endl;
                             for (int i = 0 ; i < manipulator->getIndices() ; i++)
                             {
                                 myPickingShaderProgram->setUniformValue(indexLocation, packPickingIndex(index));
@@ -1010,9 +1009,11 @@ Selectable* SofaViewer::pickObject(const QPointF& ssPoint, const QStringList& ta
                                 {
                                     if (manipulator->enabled())
                                     {
+
                                         if (index < manipulator->getIndices())
                                         {
                                             selectable = new SelectableManipulator(*(manipulator), index);
+                                            break;
                                         }
                                         else
                                         {


### PR DESCRIPTION
- Manipulators are now stored in a QList in SofaBaseScene
- Manipulators have an "enabled" and "persistent" flag to determine if the manipulator is currently usable and if it should be disabled when another one is enabled (not persistent)
- Clicking on the Manipulator's widgets in the EditView toggles the manipulators' enabled flags like radio buttons would
- The major bug breaking the GUI is fixed (it was the construction of extra DrawToolGLs in the internalDraw method that was causing the issue)
- Edit Mode also back to business (each manipulator works both for Object / Edit mode, and interactors are what decides what kind of data the manipulators interact with.

- TODO: look into why SelectedComponent gets garbage collected

