### PR TITLE
FIX: drag and drop from hierarchy after changing the scene

### DIFF
--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaBasics/DefaultMenuBar.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaBasics/DefaultMenuBar.qml
@@ -8,7 +8,6 @@ import SofaBasics 1.0
 import SofaViewListModel 1.0
 import GraphView 1.0
 import ProfilerView 1.0
-import QFileDialog 1.0
 
 MenuBar {
     id: menuBar

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaViews/Hierarchy.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaViews/Hierarchy.qml
@@ -601,13 +601,12 @@ Rectangle {
             Item {
                 id: dragItem
                 property string origin: "Hierarchy"
-                property SofaBase item: {
-                    var srcIndex = sceneModel.mapToSource(styleData.index)
-                    var theComponent = basemodel.getBaseFromIndex(srcIndex)
-                    dragItem.item = theComponent
-                }
+                property SofaBase item
                 Drag.active: mouseArea.drag.active
                 Drag.onActiveChanged: {
+                    var srcIndex = sceneModel.mapToSource(index)
+                    var theComponent = basemodel.getBaseFromIndex(srcIndex)
+                    item = theComponent
                     print("Dragging " + item.getName())
                 }
 


### PR DESCRIPTION
The dragged SofaBase was stored in the dragItem QML structure during initial treeView creation and not updated afterwards.