### PR TITLE
ADD: possibility to reorganise BaseObjects within nodes

### DIFF
--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaViews/Hierarchy.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaViews/Hierarchy.qml
@@ -777,29 +777,29 @@ Rectangle {
                     }
 
                     function dropFromHierarchy(src) {
-                        var oldIndex = src.index
-                        oldIndex = sceneModel.mapToSource(oldIndex)
-                        var theComponent = basemodel.getBaseFromIndex(oldIndex)
-                        if (!theComponent)
-                            return
+                        print("drop from Hierarchy: " + src.item.getName())
+                        var theComponent = src.item
+
                         var newIndex = styleData.index
                         newIndex = sceneModel.mapToSource(newIndex)
                         var parentNode = basemodel.getBaseFromIndex(newIndex)
 
-                        if (!parentNode.isNode()) {
+                        if (parentNode.isNode()) {
+                            var oldParent = theComponent.getFirstParent()
+
+                            if (oldParent.getPathName() !== parentNode.getPathName() &&
+                                    parentNode.getPathName() !== theComponent.getPathName()) {
+                                if (theComponent.isNode()) {
+                                    parentNode.moveChild(theComponent, oldParent)
+                                }
+                                else {
+                                    parentNode.moveObject(theComponent)
+                                }
+                            }
+                        } else {
+                            var atPlaceObject = parentNode
                             parentNode = parentNode.getFirstParent()
-                        }
-
-                        var oldParent = theComponent.getFirstParent()
-
-                        if (oldParent.getPathName() !== parentNode.getPathName() &&
-                                parentNode.getPathName() !== theComponent.getPathName()) {
-                            if (theComponent.isNode()) {
-                                parentNode.moveChild(theComponent, oldParent)
-                            }
-                            else {
-                                parentNode.moveObject(theComponent)
-                            }
+                            parentNode.insertAfter(atPlaceObject, theComponent)
                         }
                     }
 

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaNode.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaNode.cpp
@@ -399,7 +399,7 @@ void SofaNode::moveChild(SofaNode* node, SofaNode* prev_parent)
 
 void SofaNode::moveObject(SofaBaseObject* obj)
 {
-    BaseNode* p = obj->selfptr()->getContext()->toBaseNode()->getFirstParent();
+    BaseNode* p = obj->selfptr()->getContext()->toBaseNode();
     SofaNode prev_parent(DAGNode::SPtr(dynamic_cast<DAGNode*>(p)));
     if ((isInAPrefab() && !attemptToBreakPrefab())
             || (prev_parent.isInAPrefab() && !prev_parent.attemptToBreakPrefab()))
@@ -407,6 +407,34 @@ void SofaNode::moveObject(SofaBaseObject* obj)
     DAGNode* _this = self();
     _this->moveObject(obj->selfptr());
 }
+
+
+void SofaNode::insertAfter(SofaBaseObject* afterObject, SofaBaseObject* obj)
+{
+    auto olist = selfptr()->object;
+    size_t i;
+    for (i = 0 ; i < olist.size() ; ++i)
+        if (olist[i].get() == afterObject->self())
+            break;
+    if (i != olist.size())
+        insertObject(obj, i);
+}
+
+void SofaNode::insertObject(SofaBaseObject* obj, unsigned int position)
+{
+    BaseNode* p = obj->selfptr()->getContext()->toBaseNode();
+    SofaNode prev_parent(DAGNode::SPtr(dynamic_cast<DAGNode*>(p)));
+    if ((isInAPrefab() && !attemptToBreakPrefab())
+            || (prev_parent.isInAPrefab() && !prev_parent.attemptToBreakPrefab()))
+        return;
+    DAGNode* _this = self();
+    _this->moveObject(obj->selfptr());
+
+    auto olist = &selfptr()->object;
+    for (auto i = olist->end() - 1 ; i->get() != olist->get(position) ; --i)
+        olist->swap(i, i-1);
+}
+
 
 
 

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaNode.h
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaNode.h
@@ -105,6 +105,8 @@ public:
 
     Q_INVOKABLE void moveChild(SofaNode* node, SofaNode* prev_parent);
     Q_INVOKABLE void moveObject(SofaBaseObject* obj);
+    Q_INVOKABLE void insertAfter(SofaBaseObject* afterObject, SofaBaseObject* obj);
+    Q_INVOKABLE void insertObject(SofaBaseObject* obj, unsigned int position);
 
     Q_INVOKABLE void removeObject(SofaBaseObject* obj);
 


### PR DESCRIPTION
Can now drag and drop BaseObjects in the Hierarchy treeView to reorganise them

TODO implement reorganization of nodes within the same parent