### PR TITLE
Prefab saving with new Algo

### DIFF
--- a/applications-dev/plugins/SofaQtQuickGUI/data/python/SofaQtQuick.py
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/python/SofaQtQuick.py
@@ -107,17 +107,24 @@ def getAbsolutePythonPath(node):
         return node.getRoot().getName() + node.getPathName().replace("/", ".")
 
 
-def buildDataParams(obj, indent, scn):
+def buildDataParams(obj, indent, scn, prefab=None, external_deps=[]):
     s = ""
     datas = obj.getDataFields()
     links = obj.getLinks()
     for data in datas:
         if data.hasParent():
-            scn[0] += indent + "### THERE WAS A LINK. "
-            scn[0] += data.getParent().getLinkPath() + "=>" + data.getLinkPath() + "\n"
-            if data.getName() != "name":
-                relPath = os.path.relpath(data.getParent().getPathName(), data.getOwner().getContext().getPathName())
-                s += ", " + data.getName()+ "='@" + relPath +"'"
+            if prefab != None and data in external_deps:
+                scn[0] += indent + "### THERE WAS A LINK. "
+                scn[0] += data.getParent().getLinkPath() + "=>" + data.getLinkPath() + "\n"
+                if data.getName() != "name":
+                    relPath = os.path.relpath(data.getParent().getPathName(), data.getOwner().getContext().getPathName())
+                    s += ", " + data.getName()+ "='@" + relPath +"'"
+            else:
+                scn[0] += indent + "### THERE WAS A LINK. "
+                scn[0] += prefab.getPathName + "." + getParameterName(data) + "=>" + data.getLinkPath() + "\n"
+                if data.getName() != "name":
+                    relPath = os.path.relpath(prefab.getPathName(), data.getOwner().getContext().getPathName())
+                    s += ", " + data.getName()+ "='@" + relPath +"'"
         else:
             if data.getName() not in ["name","prefabname", "docstring"] and (data.isPersistent() or data.isRequired()):
                 if " " not in data.getName() and data.getName() != "Help":
@@ -137,7 +144,10 @@ def buildDataParams(obj, indent, scn):
                             else:
                                 s += ", " + data.getName() + "=" + ( v[v.find('['):v.rfind(']')+1] if "array" in repr(data.value) else repr(data.value))
     for link in links:
-        if link.getLinkedBase() and link.getName() != "context":
+        if link in external_deps and prefab != None:
+            s += ", " + link.getName() + "=" + "self." + getParameterName(link, prefab)
+
+        elif link.getLinkedBase() and link.getName() != "context":
             s += ", " + link.getName() + "='" + link.getLinkedPath() + "'"
 
     entry = Sofa.Core.ObjectFactory.getComponent(obj.getClassName())
@@ -224,7 +234,7 @@ def createItem(item, node, indent, scn):
     return item
 
 
-def hasNotYetCreatedDependencies(item, created):
+def hasNotYetCreatedDependencies(item, created, prefab=None):
     for dep in getDependenciesFor(item):
         if dep not in created:
             return True
@@ -260,6 +270,168 @@ def saveScene(node, indent, scn):
     r_createNode(node, indent, scn, created, not_created)
 
 
+
+
+
+
+
+
+
+def getExternalDependencyFromItem(prefab, item, list):
+    for d in item.getDataFields():
+        if d.hasParent() and not d.getParent().getPathName().startswith(prefab.getPathName()):
+            list.append(d)
+    for l in item.getLinks():
+        if l.getLinkedBase() != None and not l.getLinkedBase().getPathName().startswith(prefab.getPathName()) and l.getName() != "parents":
+            list.append(l)
+
+
+def r_getExternalDependencies(prefab, currentNode, list):
+    getExternalDependencyFromItem(prefab, currentNode, list)
+
+    for o in currentNode.objects:
+        getExternalDependencyFromItem(prefab, o, list)
+
+    for c in currentNode.children:
+        r_getExternalDependencies(prefab, c, list)
+
+
+def getParameterName(param, prefab):
+    return param.getPathName().replace(prefab.getPathName(), "").replace("/", "_").replace(".", "_")[1:]
+
+
+def writeExternalDependencies(external_deps, prefab, indent):
+    str = ''
+    for item in external_deps:
+        itemName = getParameterName(item, prefab)
+        if item is Sofa.Core.Data:
+            str += indent + "self.addData(name='" + itemName + "', type='" + item.typeName() + "')\n"
+        else:
+            str += indent + "self.addLink(name='" + itemName + "')\n"
+    return str
+
+
+def createItemInPrefab(item, node, indent, scn, external_deps, prefab):
+    if type(item) is Sofa.Core.Node:
+        print("creating Node " + item.getName())
+        scn[0] += indent + getAbsPythonCallPath(item.parents[0], prefab) + ".addChild('" + item.getName() + "')\n"
+    else:
+        print("creating Object " + item.getName())
+        attributes = buildDataParams(item, indent, scn, prefab, external_deps)
+        parentPath = indent + getAbsPythonCallPath(item.getContext() if type(item) == Sofa.Core.Object else item.parents[0], prefab)
+        scn[0] += parentPath + ".addObject('" + item.getClassName() + "', name='" + item.getName() + "'" + attributes + ")\n"
+    return item
+
+
+def r_createPrefab(node, indent, scn, created, not_created, external_deps, prefab):
+    for o in node.objects:
+        print("##########################" + o.getName() + "###################")
+        if not hasNotYetCreatedDependencies(o, created):
+            created.append(createItemInPrefab(o, node, indent, scn, external_deps, prefab))
+        else:
+            print("postpone creation of " + o.getName() + " because of deps")
+            scn[0] += indent + "# " + o.getName() + " (" + o.getClassName() + ") will be created later because of upstream dependencies\n"
+            not_created.append(o)
+    # Deal with components having a dependency to a component located within the same node
+    try_create_dependent_item(node, indent, scn, created, not_created)
+    for c in node.children:
+        scn[0] += "\n"
+        created.append(createItem(c, node, indent, scn))
+        r_createNode(c, indent, scn, created, not_created)
+        # Deal with components having a dependency to upstream-located or sibling-located components
+        try_create_dependent_item(node, indent, scn, created, not_created)
+
+
+def createPrefab(fileName, prefab, name, help):
+    external_deps = []
+    r_getExternalDependencies(prefab, prefab, external_deps)
+
+    print('Saving prefab in ' + fileName)
+    fd = open(fileName, "w+")
+    fd.write('"""type: SofaContent"""\n')
+    fd.write("import sys\n")
+    fd.write("import os\n")
+    fd.write("import Sofa\n")
+    fd.write("import Sofa.Core\n")
+
+    modules = []
+    modulepaths = []
+    scn = [""]
+    nodeName = prefab.getName()
+    print(prefab.name)
+    prefab.setName("self")
+    print(nodeName)
+
+
+    fd.write("# all Paths\n")
+    for p in list(dict.fromkeys(modulepaths)):
+        fd.write("sys.path.append('" + getRelPath(p, fileName) + "')\n")
+
+    fd.write('# all Modules:\n')
+    for m in list(dict.fromkeys(modules)):
+        fd.write("from " + m + " import *\n")
+
+    fd.write("class " + name + "(Sofa.Prefab):\n")
+    fd.write("    \"\"\" " + help + " \"\"\"\n")
+    fd.write("    def __init__(self, *args, **kwargs):\n")
+    fd.write("        Sofa.Prefab.__init__(self, *args, **kwargs)\n")
+
+
+    fd.write("        # external deps: " + ", ".join(dep.getName() for dep in external_deps) + "\n")
+
+    str = writeExternalDependencies(external_deps, prefab, "        ")
+    fd.write(str)
+
+    created = [prefab]
+    not_created = []
+
+    externalCreated = created
+    for item in external_deps:
+        externalCreated.append(item.getLinkedBase())
+
+    r_createPrefab(prefab, "        ", scn, created + external_deps, not_created, external_deps, prefab)
+    fd.write(scn[0])
+    prefab.setName(nodeName)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def saveAsPythonScene(fileName, node):
     root = node
     fd = open(fileName, "w+")
@@ -273,7 +445,7 @@ def saveAsPythonScene(fileName, node):
     scn = [""]
     saveScene(node, "    ", scn)
 
-#    saveRec(root, "    ", modules, modulepaths, scn, root)
+    #    saveRec(root, "    ", modules, modulepaths, scn, root)
 
     fd.write("# all Paths\n")
     for p in list(dict.fromkeys(modulepaths)):

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaProject.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaProject.cpp
@@ -544,7 +544,7 @@ bool SofaProject::createPrefab(SofaBase* node)
             py::module::import("Sofa.Core");
             py::object rootNode = sofapython3::PythonFactory::toPython(node->base()->toBaseNode());
             py::module m = py::module::import("SofaQtQuick");
-            return py::cast<bool>(m.attr("createPrefabFromNode")(fileName, rootNode, name.toStdString(), help.toStdString()));
+            return py::cast<bool>(m.attr("createPrefab")(fileName, rootNode, name.toStdString(), help.toStdString()));
         }
     }
     return false;


### PR DESCRIPTION
I've modified the saving scripts to be able to reconstruct whole scene graphs in createScene scripts, and subparts of the scene as prefabs, while:

- Keeping a decent scenegraph structure
- guaranteeing dependency graph reconstruction and component's instantiation order

The Prefabs creation also identify their dependency to external components / data in the graph, and create links to those components in their initializers, directly on the top node of the prefab. This makes all external dependencies go through the same entry point: the prefab's root node.

TODO:
- The SofaQtQuick.py file desperately needs some refactoring, we should especially consider moving all code related to script savings in a dedicated file, preferably with some object-oriented structure
- There's currently no way, from the UI, to set links to components using user interactions.
- New prefabs with dependencies aren't instantiatable currently if they have external dependencies as those dependencies have to be set before trying to create the prefab. using prefab parameters for external links, and putting the content of the prefab's scene graph creation in a doReInit function should solve that issue