### PR TITLE
New Prefab feature & saving algo 

### DIFF
--- a/applications-dev/plugins/QmlUI/src/QmlUI/Canvas.cpp
+++ b/applications-dev/plugins/QmlUI/src/QmlUI/Canvas.cpp
@@ -12,7 +12,7 @@ namespace qmlui
       d_lastModified(initData(&d_lastModified, uint(0), "lastModified",
                               "the Timestamp of the last modification of filename", false, true))
   {
-      m_componentstate = sofa::core::objectmodel::ComponentState::Loading;
+      d_componentState.setValue(sofa::core::objectmodel::ComponentState::Loading);
       d_qmlFile.setRequired(true);
   }
 
@@ -22,12 +22,12 @@ namespace qmlui
       tracker.trackData(d_lastModified);
       if (!d_qmlFile.isSet() || d_qmlFile.getExtension() != "qml")
       {
-          m_componentstate = sofa::core::objectmodel::ComponentState::Invalid;
+          d_componentState.setValue(sofa::core::objectmodel::ComponentState::Invalid);
           msg_error("Canvas") << "Canvas initialized without a qml UI file";
       }
       else
       {
-          m_componentstate = sofa::core::objectmodel::ComponentState::Valid;
+          d_componentState.setValue(sofa::core::objectmodel::ComponentState::Valid);
       }
   }
   

--- a/applications-dev/plugins/SofaQtQuickGUI/data/python/SofaQtQuick.py
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/python/SofaQtQuick.py
@@ -86,336 +86,20 @@ def getPythonModuleDocstring(mpath):
     return str(docstring)
 
 
+def createTypeConversionEngine(modulename, node, srcData, dstData, srcType, dstType):
+    engineName = "to_"+dstData.getOwner().getName() + "_" + dstData.getName()
+    if engineName not in node.objects:
+        m = importlib.import_module(modulename)
+        e = splib.TypeConversionEngine(name=engineName, dstType=dstData.typeName())
+        dstData.setParent(e.dst)
+        node.addObject(e)
+    e.addDataConversion(srcData, m.convert)
+
+
+
 ######################################################################
 #################### SCENE GRAPH / PREFABS SAVING ####################
 #######################################################################
-#def getAbsPythonCallPath(node, rootNode):
-#    if rootNode.getPathName() == "/":
-#        if node.getPathName() == "/":
-#            return rootNode.name.value
-#        return rootNode.name.value + node.getPathName().replace("/", ".")
-#    else:
-#        # example:
-#        # rootNode.getPathName() = "/Snake/physics"
-#        # node.getPathName() = "/Snake/physics/visu/eye"
-#        # relPath = physics.visu.eye
-#        return rootNode.name.value + node.getPathName().replace(rootNode.getPathName(), "").replace("/", ".")
-
-#def getAbsolutePythonPath(node):
-#    if node.getRoot() == node:
-#        return node.getName()
-#    else:
-#        return node.getRoot().getName() + node.getPathName().replace("/", ".")
-
-
-#def buildDataParams(obj, indent, scn, prefab=None, external_deps=[]):
-#    s = ""
-#    datas = obj.getDataFields()
-#    links = obj.getLinks()
-#    for data in datas:
-#        if data.hasParent():
-#            if prefab != None and data in external_deps:
-#                scn[0] += indent + "### THERE WAS A LINK. "
-#                scn[0] += data.getParent().getLinkPath() + "=>" + data.getLinkPath() + "\n"
-#                if data.getName() != "name":
-#                    relPath = os.path.relpath(data.getParent().getPathName(), data.getOwner().getContext().getPathName())
-#                    s += ", " + data.getName()+ "='@" + relPath +"'"
-#            else:
-#                scn[0] += indent + "### THERE WAS A LINK. "
-#                scn[0] += prefab.getPathName + "." + getParameterName(data) + "=>" + data.getLinkPath() + "\n"
-#                if data.getName() != "name":
-#                    relPath = os.path.relpath(prefab.getPathName(), data.getOwner().getContext().getPathName())
-#                    s += ", " + data.getName()+ "='@" + relPath +"'"
-#        else:
-#            if data.getName() not in ["name","prefabname", "docstring"] and (data.isPersistent() or data.isRequired()):
-#                if " " not in data.getName() and data.getName() != "Help":
-#                    if data.getName() != "modulepath":
-#                        if data.getName() != "depend":
-#                            v = repr(data.value)
-#                            if "DataFileName" in str(data):
-#                                if os.path.exists(os.path.dirname(SofaApplication.getScene()) + "/" + v[1:-1]):
-#                                    # If the path exists & is relative
-#                                    s += ", " + data.getName() + "='" + v[1:-1] + "'"
-#                                elif os.path.relpath(v[1:-1], os.path.dirname(SofaApplication.getScene())):
-#                                    # If the path can be expressed relative to the scene file:
-#                                    s += ", " + data.getName() + "='" + os.path.relpath(v[1:-1], os.path.dirname(SofaApplication.getScene())) + "'"
-#                                else:
-#                                    # fallback (relative path, but not relative to scene file)
-#                                    s += ", " + data.getName() + "='" + v[1:-1] + "'"
-#                            else:
-#                                s += ", " + data.getName() + "=" + ( v[v.find('['):v.rfind(']')+1] if "array" in repr(data.value) else repr(data.value))
-#    for link in links:
-#        if link in external_deps and prefab != None:
-#            s += ", " + link.getName() + "=" + "self." + getParameterName(link, prefab) + ".value"
-
-#        elif link.getLinkedBase() and link.getName() != "context":
-#            s += ", " + link.getName() + "='" + link.getLinkedPath() + "'"
-
-#    entry = Sofa.Core.ObjectFactory.getComponent(obj.getClassName())
-#    if entry.defaultTemplate != obj.getTemplateName():
-#        s += ", template='" + obj.getTemplateName() + "'"
-#    return s
-
-
-#def saveRec(node, indent, modules, modulepaths, scn, rootNode):
-#    for o in node.objects:
-#        s = buildDataParams(o, indent, scn)
-#        scn[0] += indent + getAbsPythonCallPath(node, rootNode) + ".addObject('"
-#        scn[0] += o.getClassName() + "', name='" + o.name.value + "'" + s + ")\n"
-
-#    for child in node.children:
-#        s = buildDataParams(child, indent, scn)
-#        if child.getData("prefabname") is not None:
-#            #print('createPrefab '+str(child.name))
-#            scn[0] += (indent + "####################### Prefab: " +
-#                       child.name.value + " #########################\n")
-#            scn[0] += (indent + getAbsPythonCallPath(node, rootNode) +
-#                       ".addChild(" + child.prefabname.value + "(name='"+ child.name.value +"'"+s+ "))\n")
-#            scn[0] += ("\n")
-#            dirname, filename = os.path.split(child.getDefinitionSourceFileName())
-#            modules.append(filename)
-#            modulepaths.append(dirname)
-#        else:
-#            scn[0] += (indent + "####################### Node: " + child.name.value +
-#                       " #########################\n")
-#            scn[0] += (indent + getAbsPythonCallPath(node, rootNode) +
-#                       ".addChild('" + child.name.value + "')\n")
-#            saveRec(child, indent, modules, modulepaths, scn, rootNode)
-#            scn[0] += ("\n")
-
-
-#def getRelPath(path, relativeTo):
-#    # example:
-#    # path =       /home/bruno/dev/myproject/scripts
-#    # relativeTo = /home/bruno/dev/myproject/scenes/MyCoolFile.py
-#    # return "../scripts/"
-#    if os.path.isfile(relativeTo):
-#        relativeTo = os.path.dirname(relativeTo)
-
-#    if path == relativeTo:
-#        return ""
-#    commonPrefix = os.path.commonprefix([path, relativeTo])
-#    path = path.replace(commonPrefix, "")  # /scripts
-#    if path.startswith('/'):
-#        path = path[1:]  # scripts
-#    relativeTo = relativeTo.replace(commonPrefix, "")  # scenes
-#    newPath = ""
-#    if relativeTo != "":
-#        newPath += "../"
-#        for d in relativeTo.split('/'):
-#            newPath += "../"
-
-#    newPath += path
-#    return newPath
-
-
-#def getDependenciesFor(object):
-#    if type(object) is Sofa.Core.Node:
-#        return object.parents
-#    list = []
-#    for d in object.getDataFields():
-#        if d.getParent() and type(d.getParent().getOwner()) != Sofa.Core.Node:
-#            list.append(d.getParent().getOwner())
-
-#    for l in object.getLinks():
-#        if l.getLinkedBase() and type(l.getLinkedBase()) != Sofa.Core.Node and l.getName() != "slaves":
-#            list.append(l.getLinkedBase())
-
-#    list.append(object.getContext())
-#    return list
-
-
-#def createItem(item, node, indent, scn):
-#    if type(item) is Sofa.Core.Node:
-#        scn[0] += indent + getAbsolutePythonPath(item.parents[0]) + ".addChild('" + item.getName() + "')\n"
-#    else:
-#        attributes = buildDataParams(item, indent, scn)
-#        parentPath = indent + getAbsolutePythonPath(item.getContext() if type(item) == Sofa.Core.Object else item.parents[0])
-#        scn[0] += parentPath + ".addObject('" + item.getClassName() + "', name='" + item.getName() + "'" + attributes + ")\n"
-#    return item
-
-#def createItemInPrefab(item, node, indent, scn, external_deps, prefab):
-#    if type(item) is Sofa.Core.Node:
-#        scn[0] += indent + getAbsPythonCallPath(item.parents[0], prefab) + ".addChild('" + item.getName() + "')\n"
-#    else:
-#        attributes = buildDataParams(item, indent, scn, prefab, external_deps)
-#        parentPath = indent + getAbsPythonCallPath(item.getContext() if type(item) == Sofa.Core.Object else item.parents[0], prefab)
-#        scn[0] += parentPath + ".addObject('" + item.getClassName() + "', name='" + item.getName() + "'" + attributes + ")\n"
-#    return item
-
-#def hasNotYetCreatedDependencies(item, created, prefab=None):
-#    for dep in getDependenciesFor(item):
-#        if dep not in created:
-#            return True
-#    return False
-
-
-#def try_create_dependent_item(node, indent, scn, created, not_created, external_deps = [], prefab = None):
-#    for item in not_created:
-#        if not hasNotYetCreatedDependencies(item, created):
-#            if prefab == None:
-#                created.append(createItem(item, node, indent, scn))
-#            else:
-#                created.append(createItemInPrefab(item, node, indent, scn, external_deps, prefab))
-
-#            not_created.remove(item)
-
-#def r_createNode(node, indent, scn, created, not_created, external_deps = [], prefab = None):
-#    for o in node.objects:
-#        if not hasNotYetCreatedDependencies(o, created):
-#            if prefab == None:
-#                created.append(createItem(o, node, indent, scn))
-#            else:
-#                created.append(createItemInPrefab(o, node, indent, scn, external_deps, prefab))
-#        else:
-#            scn[0] += indent + "# " + o.getName() + " (" + o.getClassName() + ") will be created later because of upstream dependencies\n"
-#            not_created.append(o)
-#    # Deal with components having a dependency to a component located within the same node
-#    try_create_dependent_item(node, indent, scn, created, not_created)
-#    for c in node.children:
-#        scn[0] += "\n"
-#        if prefab == None:
-#            created.append(createItem(c, node, indent, scn))
-#        else:
-#            created.append(createItemInPrefab(c, node, indent, scn, external_deps, prefab))
-#        r_createNode(c, indent, scn, created, not_created, external_deps, prefab)
-#        # Deal with components having a dependency to upstream-located or sibling-located components
-#        try_create_dependent_item(node, indent, scn, created, not_created, external_deps, prefab)
-
-
-#def saveScene(node, indent, scn):
-#    created = [node]
-#    not_created = []
-#    r_createNode(node, indent, scn, created, not_created)
-
-
-
-
-
-
-
-
-
-#def getExternalDependencyFromItem(prefab, item, list):
-#    for d in item.getDataFields():
-#        if d.hasParent() and not d.getParent().getPathName().startswith(prefab.getPathName()):
-#            list.append(d)
-#    for l in item.getLinks():
-#        if l.getLinkedBase() != None and not l.getLinkedBase().getPathName().startswith(prefab.getPathName()) and l.getName() != "parents":
-#            list.append(l)
-
-#def r_getExternalDependencies(prefab, currentNode, list):
-#    getExternalDependencyFromItem(prefab, currentNode, list)
-
-#    for o in currentNode.objects:
-#        getExternalDependencyFromItem(prefab, o, list)
-
-#    for c in currentNode.children:
-#        r_getExternalDependencies(prefab, c, list)
-
-
-#def getParameterName(param, prefab):
-#    return param.getPathName().replace(prefab.getPathName(), "").replace("/", "_").replace(".", "_")[1:]
-
-
-#def writeExternalDependencies(external_deps, prefab, indent):
-#    str = ''
-#    for item in external_deps:
-#        itemName = getParameterName(item, prefab)
-#        if item is Sofa.Core.Data:
-#            str += indent + "self.addPrefabParameter(name='" + itemName + "', type='" + item.typeName() + "')\n"
-#        else:
-#            str += indent + "self.addPrefabParameter(name='" + itemName + "', type='Link', help='" + item.getHelp()  + "')\n"
-#    return str
-
-
-#def r_createPrefab(node, indent, scn, created, not_created, external_deps, prefab):
-#    for o in node.objects:
-#        print("##########################" + o.getName() + "###################")
-#        if not hasNotYetCreatedDependencies(o, created):
-#            created.append(createItemInPrefab(o, node, indent, scn, external_deps, prefab))
-#        else:
-#            print("postpone creation of " + o.getName() + " because of deps")
-#            scn[0] += indent + "# " + o.getName() + " (" + o.getClassName() + ") will be created later because of upstream dependencies\n"
-#            not_created.append(o)
-#    # Deal with components having a dependency to a component located within the same node
-#    try_create_dependent_item(node, indent, scn, created, not_created)
-#    for c in node.children:
-#        scn[0] += "\n"
-#        created.append(createItemInPrefab(c, node, indent, scn, external_deps, prefab))
-#        r_createNode(c, indent, scn, created, not_created, external_deps, prefab)
-#        # Deal with components having a dependency to upstream-located or sibling-located components
-#        try_create_dependent_item(node, indent, scn, created, not_created)
-
-
-#def addExternalDepsCheck(fd, external_deps, prefab):
-#    fd.write("        if ")
-#    first = True
-#    for item in external_deps:
-#        if not first:
-#            fd.write(" or ")
-#        first = False
-#        itemName = getParameterName(item, prefab)
-#        fd.write("not self.findData('"+ itemName +"')")
-#    fd.write(':\n            return\n')
-
-#def createPrefab(fileName, prefab, name, help):
-#    external_deps = []
-#    r_getExternalDependencies(prefab, prefab, external_deps)
-
-#    print('Saving prefab in ' + fileName)
-#    fd = open(fileName, "w+")
-#    fd.write('"""type: SofaContent"""\n')
-#    fd.write("import sys\n")
-#    fd.write("import os\n")
-#    fd.write("import Sofa\n")
-#    fd.write("import Sofa.Core\n")
-
-#    modules = []
-#    modulepaths = []
-#    scn = [""]
-#    nodeName = prefab.getName()
-#    print(prefab.name)
-#    prefab.setName("self")
-#    print(nodeName)
-
-
-#    fd.write("# all Paths\n")
-#    for p in list(dict.fromkeys(modulepaths)):
-#        fd.write("sys.path.append('" + getRelPath(p, fileName) + "')\n")
-
-#    fd.write('# all Modules:\n')
-#    for m in list(dict.fromkeys(modules)):
-#        fd.write("from " + m + " import *\n")
-
-#    fd.write("class " + name + "(Sofa.Prefab):\n")
-#    fd.write("    \"\"\" " + help + " \"\"\"\n")
-#    fd.write("    def __init__(self, *args, **kwargs):\n")
-#    fd.write("        Sofa.Prefab.__init__(self, *args, **kwargs)\n")
-
-
-#    fd.write("        # external deps: " + ", ".join(dep.getName() for dep in external_deps) + "\n")
-
-#    str = writeExternalDependencies(external_deps, prefab, "        ")
-#    fd.write(str)
-
-#    created = [prefab]
-#    not_created = []
-
-#    fd.write("\n\n    def doReInit(self):\n")
-
-#    addExternalDepsCheck(fd, external_deps, prefab)
-
-#    r_createPrefab(prefab, "        ", scn, created + external_deps, not_created, external_deps, prefab)
-#    fd.write(scn[0])
-#    prefab.setName(nodeName)
-
-
-
-
-
-
-#def saveScene(node, indent, scn):
 
 def saveAsPythonPrefab(fileName, prefab, name, help):
     serializer = GraphSerializer(fileName)
@@ -428,134 +112,30 @@ def saveAsPythonScene(fileName, node):
 
 
 
+def callFunction(file, function, *args, **kwargs):
+    # First let's load that script:
+    importlib.invalidate_caches()
+
+    moduledir = os.path.dirname(file)
+    modulename = os.path.basename(file)
+    spec = importlib.util.spec_from_file_location(modulename, moduledir+"/"+modulename)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return getattr(m, function)(*args, **kwargs)
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-#def saveAsPythonScene(fileName, node):
-#    root = node
-#    fd = open(fileName, "w+")
-
-#    fd.write('""" type: SofaContent """\n')
-#    fd.write("import sys\n")
-#    fd.write("import os\n")
-
-#    modules = []
-#    modulepaths = []
-#    scn = [""]
-#    saveScene(node, "    ", scn)
-
-#    #    saveRec(root, "    ", modules, modulepaths, scn, root)
-
-#    fd.write("# all Paths\n")
-#    for p in list(dict.fromkeys(modulepaths)):
-#        if p != "":
-#            fd.write("sys.path.append('" + getRelPath(p, fileName) +
-#                     "')\n")
-
-#    fd.write('# all Modules:\n')
-#    for m in list(dict.fromkeys(modules)):
-#        fd.write("from " + m + " import *\n")
-
-#    fd.write("\n\ndef createScene("+ node.getName() +"):\n")
-#    fd.write(scn[0])
-#    return True
-
-
-#def callFunction(file, function, *args, **kwargs):
-#    # First let's load that script:
-#    importlib.invalidate_caches()
-
-#    moduledir = os.path.dirname(file)
-#    modulename = os.path.basename(file)
-#    spec = importlib.util.spec_from_file_location(modulename, moduledir+"/"+modulename)
-#    m = importlib.util.module_from_spec(spec)
-#    spec.loader.exec_module(m)
-#    return getattr(m, function)(*args, **kwargs)
-
-
-#def createTypeConversionEngine(modulename, node, srcData, dstData, srcType, dstType):
-#    engineName = "to_"+dstData.getOwner().getName() + "_" + dstData.getName()
-#    if engineName not in node.objects:
-#        m = importlib.import_module(modulename)
-#        e = splib.TypeConversionEngine(name=engineName, dstType=dstData.typeName())
-#        dstData.setParent(e.dst)
-#        node.addObject(e)
-#    e.addDataConversion(srcData, m.convert)
-
-
-#def createPrefabFromNode(fileName, node, name, help):
-#    print('Saving prefab in ' + fileName)
-#    fd = open(fileName, "w+")
-#    fd.write('"""type: SofaContent"""\n')
-#    fd.write("import sys\n")
-#    fd.write("import os\n")
-#    fd.write("import Sofa\n")
-#    fd.write("import Sofa.Core\n")
-
-#    modules = []
-#    modulepaths = []
-#    scn = [""]
-#    nodeName = node.getName()
-#    print(node.name)
-#    node.setName("self")
-#    print(nodeName)
-#    saveRec(node, "        ", modules, modulepaths, scn, node)
-#    print("saved rec")
-#    node.setName(nodeName)
-#    print(node.name)
-
-#    fd.write("# all Paths\n")
-#    for p in list(dict.fromkeys(modulepaths)):
-#        fd.write("sys.path.append('" + getRelPath(p, fileName) + "')\n")
-
-#    fd.write('# all Modules:\n')
-#    for m in list(dict.fromkeys(modules)):
-#        fd.write("from " + m + " import *\n")
-
-#    fd.write("class " + name + "(Sofa.Prefab):\n")
-#    fd.write("    \"\"\" " + help + " \"\"\"\n")
-#    fd.write("    def __init__(self, *args, **kwargs):\n")
-#    fd.write("        Sofa.Prefab.__init__(self, *args, **kwargs)\n")
-#    fd.write(scn[0])
-#    return True
-
-
-#def getPrefabMetaData(func, node):
-#    """ Retreives all meta data from a python function and stores it as datafields in the given node """
-#    inspect = importlib.import_module("inspect")
-#    f = func.__init__ if inspect.isclass(func) else func
-#    node.addData(name="modulename", value=inspect.getmodulename(f.__code__.co_filename), type="string", help="module containing the prefab", group="Infos")
-#    node.addData(name="prefabname", value=f.__code__.co_name, type="string", help="prefab's function name", group="Infos")
-#    node.addData(name="modulepath", value=f.__code__.co_filename, type="string", help="module path for this prefab", group="Infos")
-#    node.addData(name="lineno", value=f.__code__.co_firstlineno, type="int", help="first line number of the prefab in the module", group="Infos")
-#    node.addData(name="sourcecode", value=inspect.getsource(func), type="string", help="The prefab's source code", group="Infos")
-#    node.addData(name="docstring", value=func.__doc__, type="string", help="The prefab's docstring", group="Infos")
-#    return node
+def getPrefabMetaData(func, node):
+    """ Retreives all meta data from a python function and stores it as datafields in the given node """
+    inspect = importlib.import_module("inspect")
+    f = func.__init__ if inspect.isclass(func) else func
+    node.addData(name="modulename", value=inspect.getmodulename(f.__code__.co_filename), type="string", help="module containing the prefab", group="Infos")
+    node.addData(name="prefabname", value=f.__code__.co_name, type="string", help="prefab's function name", group="Infos")
+    node.addData(name="modulepath", value=f.__code__.co_filename, type="string", help="module path for this prefab", group="Infos")
+    node.addData(name="lineno", value=f.__code__.co_firstlineno, type="int", help="first line number of the prefab in the module", group="Infos")
+    node.addData(name="sourcecode", value=inspect.getsource(func), type="string", help="The prefab's source code", group="Infos")
+    node.addData(name="docstring", value=func.__doc__, type="string", help="The prefab's docstring", group="Infos")
+    return node
 
 
 

--- a/applications-dev/plugins/SofaQtQuickGUI/data/python/SofaQtQuick.py
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/python/SofaQtQuick.py
@@ -53,6 +53,7 @@ def collectMetaData(obj):
     data["lineno"] = str(inspect.findsource(obj.__original__ if "__original__" in dir(obj) else obj)[1])
     return data
 
+
 # returns a dictionary of all callable objects in the module, with their type as key
 def getPythonModuleContent(moduledir, modulename):
     objects = {}
@@ -72,6 +73,7 @@ def getPythonModuleContent(moduledir, modulename):
             if meta != None:
                 objects[i] = meta
     return objects
+
 
 def getPythonModuleDocstring(mpath):
     "Get module-level docstring of Python module at mpath, e.g. 'path/to/file.py'."
@@ -98,17 +100,31 @@ def getAbsPythonCallPath(node, rootNode):
         # relPath = physics.visu.eye
         return rootNode.name.value + node.getPathName().replace(rootNode.getPathName(), "").replace("/", ".")
 
-def buildDataParams(obj, indent, scn):
+def getAbsolutePythonPath(node):
+    if node.getRoot() == node:
+        return node.getName()
+    else:
+        return node.getRoot().getName() + node.getPathName().replace("/", ".")
+
+
+def buildDataParams(obj, indent, scn, prefab=None, external_deps=[]):
     s = ""
     datas = obj.getDataFields()
     links = obj.getLinks()
     for data in datas:
         if data.hasParent():
-            scn[0] += indent + "### THERE WAS A LINK. "
-            scn[0] += data.getParent().getLinkPath() + "=>" + data.getLinkPath() + "\n"
-            if data.getName() != "name":
-                relPath = os.path.relpath(data.getParent().getPathName(), data.getOwner().getContext().getPathName())
-                s += ", " + data.getName()+ "='@" + relPath +"'"
+            if prefab != None and data in external_deps:
+                scn[0] += indent + "### THERE WAS A LINK. "
+                scn[0] += data.getParent().getLinkPath() + "=>" + data.getLinkPath() + "\n"
+                if data.getName() != "name":
+                    relPath = os.path.relpath(data.getParent().getPathName(), data.getOwner().getContext().getPathName())
+                    s += ", " + data.getName()+ "='@" + relPath +"'"
+            else:
+                scn[0] += indent + "### THERE WAS A LINK. "
+                scn[0] += prefab.getPathName + "." + getParameterName(data) + "=>" + data.getLinkPath() + "\n"
+                if data.getName() != "name":
+                    relPath = os.path.relpath(prefab.getPathName(), data.getOwner().getContext().getPathName())
+                    s += ", " + data.getName()+ "='@" + relPath +"'"
         else:
             if data.getName() not in ["name","prefabname", "docstring"] and (data.isPersistent() or data.isRequired()):
                 if " " not in data.getName() and data.getName() != "Help":
@@ -128,13 +144,17 @@ def buildDataParams(obj, indent, scn):
                             else:
                                 s += ", " + data.getName() + "=" + ( v[v.find('['):v.rfind(']')+1] if "array" in repr(data.value) else repr(data.value))
     for link in links:
-        if link.getLinkedBase() and link.getName() != "context":
+        if link in external_deps and prefab != None:
+            s += ", " + link.getName() + "=" + "self." + getParameterName(link, prefab)
+
+        elif link.getLinkedBase() and link.getName() != "context":
             s += ", " + link.getName() + "='" + link.getLinkedPath() + "'"
 
     entry = Sofa.Core.ObjectFactory.getComponent(obj.getClassName())
     if entry.defaultTemplate != obj.getTemplateName():
         s += ", template='" + obj.getTemplateName() + "'"
     return s
+
 
 def saveRec(node, indent, modules, modulepaths, scn, rootNode):
     for o in node.objects:
@@ -188,8 +208,6 @@ def getRelPath(path, relativeTo):
     return newPath
 
 
-
-
 def getDependenciesFor(object):
     if type(object) is Sofa.Core.Node:
         return object.parents
@@ -206,47 +224,222 @@ def getDependenciesFor(object):
     return list
 
 
-def getNodeDepth(node):
-    n = 0
-    for p in node.parents:
-        n = max(getNodeDepth(p)+1, n)
-    return n
-
-
-def getDependencyDepth(item):
-    n = 0
+def createItem(item, node, indent, scn):
     if type(item) is Sofa.Core.Node:
-        return getNodeDepth(item)
+        scn[0] += indent + getAbsolutePythonPath(item.parents[0]) + ".addChild('" + item.getName() + "')\n"
     else:
-        deps = getDependenciesFor(item)
-
-        for d in deps:
-            n = max(getDependencyDepth(d)+1, n)
-
-    return n
+        attributes = buildDataParams(item, indent, scn)
+        parentPath = indent + getAbsolutePythonPath(item.getContext() if type(item) == Sofa.Core.Object else item.parents[0])
+        scn[0] += parentPath + ".addObject('" + item.getClassName() + "', name='" + item.getName() + "'" + attributes + ")\n"
+    return item
 
 
-def getDependencyDepthMap(root, map):
-    map[root] = getNodeDepth(root)
-    for o in root.objects:
-        map[o] = getDependencyDepth(o)
-    for c in root.children:
-        map.update(getDependencyDepthMap(c, map))
-    return sorted(map.items(), key=lambda item: item[1])
+def hasNotYetCreatedDependencies(item, created, prefab=None):
+    for dep in getDependenciesFor(item):
+        if dep not in created:
+            return True
+    return False
 
 
+def try_create_dependent_item(node, indent, scn, created, not_created, external_deps = [], prefab = None):
+    for item in not_created:
+        if not hasNotYetCreatedDependencies(item, created):
+            if prefab == None:
+                created.append(createItem(item, node, indent, scn))
+            else:
+                created.append(createItemInPrefab(item, node, indent, scn, external_deps, prefab))
+
+            not_created.remove(item)
+
+def r_createNode(node, indent, scn, created, not_created, external_deps = [], prefab = None):
+    for o in node.objects:
+        if not hasNotYetCreatedDependencies(o, created):
+            if prefab == None:
+                created.append(createItem(o, node, indent, scn))
+            else:
+                created.append(createItemInPrefab(o, node, indent, scn, external_deps, prefab))
+        else:
+            scn[0] += indent + "# " + o.getName() + " (" + o.getClassName() + ") will be created later because of upstream dependencies\n"
+            not_created.append(o)
+    # Deal with components having a dependency to a component located within the same node
+    try_create_dependent_item(node, indent, scn, created, not_created)
+    for c in node.children:
+        scn[0] += "\n"
+        if prefab == None:
+            created.append(createItem(c, node, indent, scn))
+        else:
+            created.append(createItemInPrefab(c, node, indent, scn, external_deps, prefab))
+        r_createNode(c, indent, scn, created, not_created, external_deps, prefab)
+        # Deal with components having a dependency to upstream-located or sibling-located components
+        try_create_dependent_item(node, indent, scn, created, not_created, external_deps, prefab)
 
 
 def saveScene(node, indent, scn):
-    map = getDependencyDepthMap(node, {})
-    map.pop(0)
-    for i in map:
-        if type(i[0]) is Sofa.Core.Node:
-            scn[0] += indent + getAbsPythonCallPath(i[0].parents[0], node) + ".addChild('" + i[0].getName() + "')\n"
+    created = [node]
+    not_created = []
+    r_createNode(node, indent, scn, created, not_created)
+
+
+
+
+
+
+
+
+
+def getExternalDependencyFromItem(prefab, item, list):
+    for d in item.getDataFields():
+        if d.hasParent() and not d.getParent().getPathName().startswith(prefab.getPathName()):
+            list.append(d)
+    for l in item.getLinks():
+        if l.getLinkedBase() != None and not l.getLinkedBase().getPathName().startswith(prefab.getPathName()) and l.getName() != "parents":
+            list.append(l)
+
+
+def r_getExternalDependencies(prefab, currentNode, list):
+    getExternalDependencyFromItem(prefab, currentNode, list)
+
+    for o in currentNode.objects:
+        getExternalDependencyFromItem(prefab, o, list)
+
+    for c in currentNode.children:
+        r_getExternalDependencies(prefab, c, list)
+
+
+def getParameterName(param, prefab):
+    return param.getPathName().replace(prefab.getPathName(), "").replace("/", "_").replace(".", "_")[1:]
+
+
+def writeExternalDependencies(external_deps, prefab, indent):
+    str = ''
+    for item in external_deps:
+        itemName = getParameterName(item, prefab)
+        if item is Sofa.Core.Data:
+            str += indent + "self.addData(name='" + itemName + "', type='" + item.typeName() + "')\n"
         else:
-            attributes = buildDataParams(i[0], indent, scn)
-            parentPath = indent + getAbsPythonCallPath(i[0].getContext() if type(i[0]) == Sofa.Core.Object else i[0].parents[0], node)
-            scn[0] += parentPath + ".addObject('" + i[0].getClassName() + "', name='" + i[0].getName() + "'" + attributes + ")\n"
+            str += indent + "self.addLink(name='" + itemName + "')\n"
+    return str
+
+
+def createItemInPrefab(item, node, indent, scn, external_deps, prefab):
+    if type(item) is Sofa.Core.Node:
+        print("creating Node " + item.getName())
+        scn[0] += indent + getAbsPythonCallPath(item.parents[0], prefab) + ".addChild('" + item.getName() + "')\n"
+    else:
+        print("creating Object " + item.getName())
+        attributes = buildDataParams(item, indent, scn, prefab, external_deps)
+        parentPath = indent + getAbsPythonCallPath(item.getContext() if type(item) == Sofa.Core.Object else item.parents[0], prefab)
+        scn[0] += parentPath + ".addObject('" + item.getClassName() + "', name='" + item.getName() + "'" + attributes + ")\n"
+    return item
+
+
+def r_createPrefab(node, indent, scn, created, not_created, external_deps, prefab):
+    for o in node.objects:
+        print("##########################" + o.getName() + "###################")
+        if not hasNotYetCreatedDependencies(o, created):
+            created.append(createItemInPrefab(o, node, indent, scn, external_deps, prefab))
+        else:
+            print("postpone creation of " + o.getName() + " because of deps")
+            scn[0] += indent + "# " + o.getName() + " (" + o.getClassName() + ") will be created later because of upstream dependencies\n"
+            not_created.append(o)
+    # Deal with components having a dependency to a component located within the same node
+    try_create_dependent_item(node, indent, scn, created, not_created)
+    for c in node.children:
+        scn[0] += "\n"
+        created.append(createItemInPrefab(c, node, indent, scn, external_deps, prefab))
+        r_createNode(c, indent, scn, created, not_created, external_deps, prefab)
+        # Deal with components having a dependency to upstream-located or sibling-located components
+        try_create_dependent_item(node, indent, scn, created, not_created)
+
+
+def createPrefab(fileName, prefab, name, help):
+    external_deps = []
+    r_getExternalDependencies(prefab, prefab, external_deps)
+
+    print('Saving prefab in ' + fileName)
+    fd = open(fileName, "w+")
+    fd.write('"""type: SofaContent"""\n')
+    fd.write("import sys\n")
+    fd.write("import os\n")
+    fd.write("import Sofa\n")
+    fd.write("import Sofa.Core\n")
+
+    modules = []
+    modulepaths = []
+    scn = [""]
+    nodeName = prefab.getName()
+    print(prefab.name)
+    prefab.setName("self")
+    print(nodeName)
+
+
+    fd.write("# all Paths\n")
+    for p in list(dict.fromkeys(modulepaths)):
+        fd.write("sys.path.append('" + getRelPath(p, fileName) + "')\n")
+
+    fd.write('# all Modules:\n')
+    for m in list(dict.fromkeys(modules)):
+        fd.write("from " + m + " import *\n")
+
+    fd.write("class " + name + "(Sofa.Prefab):\n")
+    fd.write("    \"\"\" " + help + " \"\"\"\n")
+    fd.write("    def __init__(self, *args, **kwargs):\n")
+    fd.write("        Sofa.Prefab.__init__(self, *args, **kwargs)\n")
+
+
+    fd.write("        # external deps: " + ", ".join(dep.getName() for dep in external_deps) + "\n")
+
+    str = writeExternalDependencies(external_deps, prefab, "        ")
+    fd.write(str)
+
+    created = [prefab]
+    not_created = []
+
+    externalCreated = created
+    for item in external_deps:
+        externalCreated.append(item.getLinkedBase())
+
+    r_createPrefab(prefab, "        ", scn, created + external_deps, not_created, external_deps, prefab)
+    fd.write(scn[0])
+    prefab.setName(nodeName)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 def saveAsPythonScene(fileName, node):
@@ -262,7 +455,7 @@ def saveAsPythonScene(fileName, node):
     scn = [""]
     saveScene(node, "    ", scn)
 
-#    saveRec(root, "    ", modules, modulepaths, scn, root)
+    #    saveRec(root, "    ", modules, modulepaths, scn, root)
 
     fd.write("# all Paths\n")
     for p in list(dict.fromkeys(modulepaths)):
@@ -277,6 +470,7 @@ def saveAsPythonScene(fileName, node):
     fd.write("\n\ndef createScene("+ node.getName() +"):\n")
     fd.write(scn[0])
     return True
+
 
 def callFunction(file, function, *args, **kwargs):
     # First let's load that script:
@@ -308,7 +502,6 @@ def createPrefabFromNode(fileName, node, name, help):
     fd.write("import os\n")
     fd.write("import Sofa\n")
     fd.write("import Sofa.Core\n")
-
 
     modules = []
     modulepaths = []

--- a/applications-dev/plugins/SofaQtQuickGUI/data/python/SofaQtQuick.py
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/python/SofaQtQuick.py
@@ -11,6 +11,7 @@ import Sofa.Core
 import Sofa.Helper
 import SofaApplication
 import splib
+from graph_serialization import GraphSerializer
 
 ######################################################################
 #################### INTROSPECTING HELPER METHODS ####################
@@ -87,476 +88,474 @@ def getPythonModuleDocstring(mpath):
 
 ######################################################################
 #################### SCENE GRAPH / PREFABS SAVING ####################
-######################################################################
-def getAbsPythonCallPath(node, rootNode):
-    if rootNode.getPathName() == "/":
-        if node.getPathName() == "/":
-            return rootNode.name.value
-        return rootNode.name.value + node.getPathName().replace("/", ".")
-    else:
-        # example:
-        # rootNode.getPathName() = "/Snake/physics"
-        # node.getPathName() = "/Snake/physics/visu/eye"
-        # relPath = physics.visu.eye
-        return rootNode.name.value + node.getPathName().replace(rootNode.getPathName(), "").replace("/", ".")
-
-def getAbsolutePythonPath(node):
-    if node.getRoot() == node:
-        return node.getName()
-    else:
-        return node.getRoot().getName() + node.getPathName().replace("/", ".")
-
-
-def buildDataParams(obj, indent, scn, prefab=None, external_deps=[]):
-    s = ""
-    datas = obj.getDataFields()
-    links = obj.getLinks()
-    for data in datas:
-        if data.hasParent():
-            if prefab != None and data in external_deps:
-                scn[0] += indent + "### THERE WAS A LINK. "
-                scn[0] += data.getParent().getLinkPath() + "=>" + data.getLinkPath() + "\n"
-                if data.getName() != "name":
-                    relPath = os.path.relpath(data.getParent().getPathName(), data.getOwner().getContext().getPathName())
-                    s += ", " + data.getName()+ "='@" + relPath +"'"
-            else:
-                scn[0] += indent + "### THERE WAS A LINK. "
-                scn[0] += prefab.getPathName + "." + getParameterName(data) + "=>" + data.getLinkPath() + "\n"
-                if data.getName() != "name":
-                    relPath = os.path.relpath(prefab.getPathName(), data.getOwner().getContext().getPathName())
-                    s += ", " + data.getName()+ "='@" + relPath +"'"
-        else:
-            if data.getName() not in ["name","prefabname", "docstring"] and (data.isPersistent() or data.isRequired()):
-                if " " not in data.getName() and data.getName() != "Help":
-                    if data.getName() != "modulepath":
-                        if data.getName() != "depend":
-                            v = repr(data.value)
-                            if "DataFileName" in str(data):
-                                if os.path.exists(os.path.dirname(SofaApplication.getScene()) + "/" + v[1:-1]):
-                                    # If the path exists & is relative
-                                    s += ", " + data.getName() + "='" + v[1:-1] + "'"
-                                elif os.path.relpath(v[1:-1], os.path.dirname(SofaApplication.getScene())):
-                                    # If the path can be expressed relative to the scene file:
-                                    s += ", " + data.getName() + "='" + os.path.relpath(v[1:-1], os.path.dirname(SofaApplication.getScene())) + "'"
-                                else:
-                                    # fallback (relative path, but not relative to scene file)
-                                    s += ", " + data.getName() + "='" + v[1:-1] + "'"
-                            else:
-                                s += ", " + data.getName() + "=" + ( v[v.find('['):v.rfind(']')+1] if "array" in repr(data.value) else repr(data.value))
-    for link in links:
-        if link in external_deps and prefab != None:
-            s += ", " + link.getName() + "=" + "self." + getParameterName(link, prefab) + ".value"
-
-        elif link.getLinkedBase() and link.getName() != "context":
-            s += ", " + link.getName() + "='" + link.getLinkedPath() + "'"
-
-    entry = Sofa.Core.ObjectFactory.getComponent(obj.getClassName())
-    if entry.defaultTemplate != obj.getTemplateName():
-        s += ", template='" + obj.getTemplateName() + "'"
-    return s
-
-
-def saveRec(node, indent, modules, modulepaths, scn, rootNode):
-    for o in node.objects:
-        s = buildDataParams(o, indent, scn)
-        scn[0] += indent + getAbsPythonCallPath(node, rootNode) + ".addObject('"
-        scn[0] += o.getClassName() + "', name='" + o.name.value + "'" + s + ")\n"
-
-    for child in node.children:
-        s = buildDataParams(child, indent, scn)
-        if child.getData("prefabname") is not None:
-            #print('createPrefab '+str(child.name))
-            scn[0] += (indent + "####################### Prefab: " +
-                       child.name.value + " #########################\n")
-            scn[0] += (indent + getAbsPythonCallPath(node, rootNode) +
-                       ".addChild(" + child.prefabname.value + "(name='"+ child.name.value +"'"+s+ "))\n")
-            scn[0] += ("\n")
-            dirname, filename = os.path.split(child.getDefinitionSourceFileName())
-            modules.append(filename)
-            modulepaths.append(dirname)
-        else:
-            scn[0] += (indent + "####################### Node: " + child.name.value +
-                       " #########################\n")
-            scn[0] += (indent + getAbsPythonCallPath(node, rootNode) +
-                       ".addChild('" + child.name.value + "')\n")
-            saveRec(child, indent, modules, modulepaths, scn, rootNode)
-            scn[0] += ("\n")
-
-
-def getRelPath(path, relativeTo):
-    # example:
-    # path =       /home/bruno/dev/myproject/scripts
-    # relativeTo = /home/bruno/dev/myproject/scenes/MyCoolFile.py
-    # return "../scripts/"
-    if os.path.isfile(relativeTo):
-        relativeTo = os.path.dirname(relativeTo)
-
-    if path == relativeTo:
-        return ""
-    commonPrefix = os.path.commonprefix([path, relativeTo])
-    path = path.replace(commonPrefix, "")  # /scripts
-    if path.startswith('/'):
-        path = path[1:]  # scripts
-    relativeTo = relativeTo.replace(commonPrefix, "")  # scenes
-    newPath = ""
-    if relativeTo != "":
-        newPath += "../"
-        for d in relativeTo.split('/'):
-            newPath += "../"
-
-    newPath += path
-    return newPath
-
-
-def getDependenciesFor(object):
-    if type(object) is Sofa.Core.Node:
-        return object.parents
-    list = []
-    for d in object.getDataFields():
-        if d.getParent() and type(d.getParent().getOwner()) != Sofa.Core.Node:
-            list.append(d.getParent().getOwner())
-
-    for l in object.getLinks():
-        if l.getLinkedBase() and type(l.getLinkedBase()) != Sofa.Core.Node and l.getName() != "slaves":
-            list.append(l.getLinkedBase())
-
-    list.append(object.getContext())
-    return list
-
-
-def createItem(item, node, indent, scn):
-    if type(item) is Sofa.Core.Node:
-        scn[0] += indent + getAbsolutePythonPath(item.parents[0]) + ".addChild('" + item.getName() + "')\n"
-    else:
-        attributes = buildDataParams(item, indent, scn)
-        parentPath = indent + getAbsolutePythonPath(item.getContext() if type(item) == Sofa.Core.Object else item.parents[0])
-        scn[0] += parentPath + ".addObject('" + item.getClassName() + "', name='" + item.getName() + "'" + attributes + ")\n"
-    return item
-
-
-def hasNotYetCreatedDependencies(item, created, prefab=None):
-    for dep in getDependenciesFor(item):
-        if dep not in created:
-            return True
-    return False
-
-
-def try_create_dependent_item(node, indent, scn, created, not_created, external_deps = [], prefab = None):
-    for item in not_created:
-        if not hasNotYetCreatedDependencies(item, created):
-            if prefab == None:
-                created.append(createItem(item, node, indent, scn))
-            else:
-                created.append(createItemInPrefab(item, node, indent, scn, external_deps, prefab))
-
-            not_created.remove(item)
-
-def r_createNode(node, indent, scn, created, not_created, external_deps = [], prefab = None):
-    for o in node.objects:
-        if not hasNotYetCreatedDependencies(o, created):
-            if prefab == None:
-                created.append(createItem(o, node, indent, scn))
-            else:
-                created.append(createItemInPrefab(o, node, indent, scn, external_deps, prefab))
-        else:
-            scn[0] += indent + "# " + o.getName() + " (" + o.getClassName() + ") will be created later because of upstream dependencies\n"
-            not_created.append(o)
-    # Deal with components having a dependency to a component located within the same node
-    try_create_dependent_item(node, indent, scn, created, not_created)
-    for c in node.children:
-        scn[0] += "\n"
-        if prefab == None:
-            created.append(createItem(c, node, indent, scn))
-        else:
-            created.append(createItemInPrefab(c, node, indent, scn, external_deps, prefab))
-        r_createNode(c, indent, scn, created, not_created, external_deps, prefab)
-        # Deal with components having a dependency to upstream-located or sibling-located components
-        try_create_dependent_item(node, indent, scn, created, not_created, external_deps, prefab)
-
-
-def saveScene(node, indent, scn):
-    created = [node]
-    not_created = []
-    r_createNode(node, indent, scn, created, not_created)
-
-
-
-
-
-
-
-
-
-def getExternalDependencyFromItem(prefab, item, list):
-    for d in item.getDataFields():
-        if d.hasParent() and not d.getParent().getPathName().startswith(prefab.getPathName()):
-            list.append(d)
-    for l in item.getLinks():
-        if l.getLinkedBase() != None and not l.getLinkedBase().getPathName().startswith(prefab.getPathName()) and l.getName() != "parents":
-            list.append(l)
-
-
-def r_getExternalDependencies(prefab, currentNode, list):
-    getExternalDependencyFromItem(prefab, currentNode, list)
-
-    for o in currentNode.objects:
-        getExternalDependencyFromItem(prefab, o, list)
-
-    for c in currentNode.children:
-        r_getExternalDependencies(prefab, c, list)
-
-
-def getParameterName(param, prefab):
-    return param.getPathName().replace(prefab.getPathName(), "").replace("/", "_").replace(".", "_")[1:]
-
-
-def writeExternalDependencies(external_deps, prefab, indent):
-    str = ''
-    for item in external_deps:
-        itemName = getParameterName(item, prefab)
-        if item is Sofa.Core.Data:
-            str += indent + "self.addPrefabParameter(name='" + itemName + "', type='" + item.typeName() + "')\n"
-        else:
-            str += indent + "self.addPrefabParameter(name='" + itemName + "', type='Link', help='" + item.getHelp()  + "')\n"
-    return str
-
-
-def createItemInPrefab(item, node, indent, scn, external_deps, prefab):
-    if type(item) is Sofa.Core.Node:
-        print("creating Node " + item.getName())
-        scn[0] += indent + getAbsPythonCallPath(item.parents[0], prefab) + ".addChild('" + item.getName() + "')\n"
-    else:
-        print("creating Object " + item.getName())
-        attributes = buildDataParams(item, indent, scn, prefab, external_deps)
-        parentPath = indent + getAbsPythonCallPath(item.getContext() if type(item) == Sofa.Core.Object else item.parents[0], prefab)
-        scn[0] += parentPath + ".addObject('" + item.getClassName() + "', name='" + item.getName() + "'" + attributes + ")\n"
-    return item
-
-
-def r_createPrefab(node, indent, scn, created, not_created, external_deps, prefab):
-    for o in node.objects:
-        print("##########################" + o.getName() + "###################")
-        if not hasNotYetCreatedDependencies(o, created):
-            created.append(createItemInPrefab(o, node, indent, scn, external_deps, prefab))
-        else:
-            print("postpone creation of " + o.getName() + " because of deps")
-            scn[0] += indent + "# " + o.getName() + " (" + o.getClassName() + ") will be created later because of upstream dependencies\n"
-            not_created.append(o)
-    # Deal with components having a dependency to a component located within the same node
-    try_create_dependent_item(node, indent, scn, created, not_created)
-    for c in node.children:
-        scn[0] += "\n"
-        created.append(createItemInPrefab(c, node, indent, scn, external_deps, prefab))
-        r_createNode(c, indent, scn, created, not_created, external_deps, prefab)
-        # Deal with components having a dependency to upstream-located or sibling-located components
-        try_create_dependent_item(node, indent, scn, created, not_created)
-
-
-def addExternalDepsCheck(fd, external_deps, prefab):
-    fd.write("        if ")
-    first = True
-    for item in external_deps:
-        if not first:
-            fd.write(" or ")
-        first = False
-        itemName = getParameterName(item, prefab)
-        fd.write("not self.findData('"+ itemName +"')")
-    fd.write(':\n            return\n')
-
-def createPrefab(fileName, prefab, name, help):
-    external_deps = []
-    r_getExternalDependencies(prefab, prefab, external_deps)
-
-    print('Saving prefab in ' + fileName)
-    fd = open(fileName, "w+")
-    fd.write('"""type: SofaContent"""\n')
-    fd.write("import sys\n")
-    fd.write("import os\n")
-    fd.write("import Sofa\n")
-    fd.write("import Sofa.Core\n")
-
-    modules = []
-    modulepaths = []
-    scn = [""]
-    nodeName = prefab.getName()
-    print(prefab.name)
-    prefab.setName("self")
-    print(nodeName)
-
-
-    fd.write("# all Paths\n")
-    for p in list(dict.fromkeys(modulepaths)):
-        fd.write("sys.path.append('" + getRelPath(p, fileName) + "')\n")
-
-    fd.write('# all Modules:\n')
-    for m in list(dict.fromkeys(modules)):
-        fd.write("from " + m + " import *\n")
-
-    fd.write("class " + name + "(Sofa.Prefab):\n")
-    fd.write("    \"\"\" " + help + " \"\"\"\n")
-    fd.write("    def __init__(self, *args, **kwargs):\n")
-    fd.write("        Sofa.Prefab.__init__(self, *args, **kwargs)\n")
-
-
-    fd.write("        # external deps: " + ", ".join(dep.getName() for dep in external_deps) + "\n")
-
-    str = writeExternalDependencies(external_deps, prefab, "        ")
-    fd.write(str)
-
-    created = [prefab]
-    not_created = []
-
-    externalCreated = created
-    for item in external_deps:
-        externalCreated.append(item.getLinkedBase())
-
-    fd.write("\n\n    def doReInit(self):\n")
-
-    addExternalDepsCheck(fd, external_deps, prefab)
-
-    r_createPrefab(prefab, "        ", scn, created + external_deps, not_created, external_deps, prefab)
-    fd.write(scn[0])
-    prefab.setName(nodeName)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+#######################################################################
+#def getAbsPythonCallPath(node, rootNode):
+#    if rootNode.getPathName() == "/":
+#        if node.getPathName() == "/":
+#            return rootNode.name.value
+#        return rootNode.name.value + node.getPathName().replace("/", ".")
+#    else:
+#        # example:
+#        # rootNode.getPathName() = "/Snake/physics"
+#        # node.getPathName() = "/Snake/physics/visu/eye"
+#        # relPath = physics.visu.eye
+#        return rootNode.name.value + node.getPathName().replace(rootNode.getPathName(), "").replace("/", ".")
+
+#def getAbsolutePythonPath(node):
+#    if node.getRoot() == node:
+#        return node.getName()
+#    else:
+#        return node.getRoot().getName() + node.getPathName().replace("/", ".")
+
+
+#def buildDataParams(obj, indent, scn, prefab=None, external_deps=[]):
+#    s = ""
+#    datas = obj.getDataFields()
+#    links = obj.getLinks()
+#    for data in datas:
+#        if data.hasParent():
+#            if prefab != None and data in external_deps:
+#                scn[0] += indent + "### THERE WAS A LINK. "
+#                scn[0] += data.getParent().getLinkPath() + "=>" + data.getLinkPath() + "\n"
+#                if data.getName() != "name":
+#                    relPath = os.path.relpath(data.getParent().getPathName(), data.getOwner().getContext().getPathName())
+#                    s += ", " + data.getName()+ "='@" + relPath +"'"
+#            else:
+#                scn[0] += indent + "### THERE WAS A LINK. "
+#                scn[0] += prefab.getPathName + "." + getParameterName(data) + "=>" + data.getLinkPath() + "\n"
+#                if data.getName() != "name":
+#                    relPath = os.path.relpath(prefab.getPathName(), data.getOwner().getContext().getPathName())
+#                    s += ", " + data.getName()+ "='@" + relPath +"'"
+#        else:
+#            if data.getName() not in ["name","prefabname", "docstring"] and (data.isPersistent() or data.isRequired()):
+#                if " " not in data.getName() and data.getName() != "Help":
+#                    if data.getName() != "modulepath":
+#                        if data.getName() != "depend":
+#                            v = repr(data.value)
+#                            if "DataFileName" in str(data):
+#                                if os.path.exists(os.path.dirname(SofaApplication.getScene()) + "/" + v[1:-1]):
+#                                    # If the path exists & is relative
+#                                    s += ", " + data.getName() + "='" + v[1:-1] + "'"
+#                                elif os.path.relpath(v[1:-1], os.path.dirname(SofaApplication.getScene())):
+#                                    # If the path can be expressed relative to the scene file:
+#                                    s += ", " + data.getName() + "='" + os.path.relpath(v[1:-1], os.path.dirname(SofaApplication.getScene())) + "'"
+#                                else:
+#                                    # fallback (relative path, but not relative to scene file)
+#                                    s += ", " + data.getName() + "='" + v[1:-1] + "'"
+#                            else:
+#                                s += ", " + data.getName() + "=" + ( v[v.find('['):v.rfind(']')+1] if "array" in repr(data.value) else repr(data.value))
+#    for link in links:
+#        if link in external_deps and prefab != None:
+#            s += ", " + link.getName() + "=" + "self." + getParameterName(link, prefab) + ".value"
+
+#        elif link.getLinkedBase() and link.getName() != "context":
+#            s += ", " + link.getName() + "='" + link.getLinkedPath() + "'"
+
+#    entry = Sofa.Core.ObjectFactory.getComponent(obj.getClassName())
+#    if entry.defaultTemplate != obj.getTemplateName():
+#        s += ", template='" + obj.getTemplateName() + "'"
+#    return s
+
+
+#def saveRec(node, indent, modules, modulepaths, scn, rootNode):
+#    for o in node.objects:
+#        s = buildDataParams(o, indent, scn)
+#        scn[0] += indent + getAbsPythonCallPath(node, rootNode) + ".addObject('"
+#        scn[0] += o.getClassName() + "', name='" + o.name.value + "'" + s + ")\n"
+
+#    for child in node.children:
+#        s = buildDataParams(child, indent, scn)
+#        if child.getData("prefabname") is not None:
+#            #print('createPrefab '+str(child.name))
+#            scn[0] += (indent + "####################### Prefab: " +
+#                       child.name.value + " #########################\n")
+#            scn[0] += (indent + getAbsPythonCallPath(node, rootNode) +
+#                       ".addChild(" + child.prefabname.value + "(name='"+ child.name.value +"'"+s+ "))\n")
+#            scn[0] += ("\n")
+#            dirname, filename = os.path.split(child.getDefinitionSourceFileName())
+#            modules.append(filename)
+#            modulepaths.append(dirname)
+#        else:
+#            scn[0] += (indent + "####################### Node: " + child.name.value +
+#                       " #########################\n")
+#            scn[0] += (indent + getAbsPythonCallPath(node, rootNode) +
+#                       ".addChild('" + child.name.value + "')\n")
+#            saveRec(child, indent, modules, modulepaths, scn, rootNode)
+#            scn[0] += ("\n")
+
+
+#def getRelPath(path, relativeTo):
+#    # example:
+#    # path =       /home/bruno/dev/myproject/scripts
+#    # relativeTo = /home/bruno/dev/myproject/scenes/MyCoolFile.py
+#    # return "../scripts/"
+#    if os.path.isfile(relativeTo):
+#        relativeTo = os.path.dirname(relativeTo)
+
+#    if path == relativeTo:
+#        return ""
+#    commonPrefix = os.path.commonprefix([path, relativeTo])
+#    path = path.replace(commonPrefix, "")  # /scripts
+#    if path.startswith('/'):
+#        path = path[1:]  # scripts
+#    relativeTo = relativeTo.replace(commonPrefix, "")  # scenes
+#    newPath = ""
+#    if relativeTo != "":
+#        newPath += "../"
+#        for d in relativeTo.split('/'):
+#            newPath += "../"
+
+#    newPath += path
+#    return newPath
+
+
+#def getDependenciesFor(object):
+#    if type(object) is Sofa.Core.Node:
+#        return object.parents
+#    list = []
+#    for d in object.getDataFields():
+#        if d.getParent() and type(d.getParent().getOwner()) != Sofa.Core.Node:
+#            list.append(d.getParent().getOwner())
+
+#    for l in object.getLinks():
+#        if l.getLinkedBase() and type(l.getLinkedBase()) != Sofa.Core.Node and l.getName() != "slaves":
+#            list.append(l.getLinkedBase())
+
+#    list.append(object.getContext())
+#    return list
+
+
+#def createItem(item, node, indent, scn):
+#    if type(item) is Sofa.Core.Node:
+#        scn[0] += indent + getAbsolutePythonPath(item.parents[0]) + ".addChild('" + item.getName() + "')\n"
+#    else:
+#        attributes = buildDataParams(item, indent, scn)
+#        parentPath = indent + getAbsolutePythonPath(item.getContext() if type(item) == Sofa.Core.Object else item.parents[0])
+#        scn[0] += parentPath + ".addObject('" + item.getClassName() + "', name='" + item.getName() + "'" + attributes + ")\n"
+#    return item
+
+#def createItemInPrefab(item, node, indent, scn, external_deps, prefab):
+#    if type(item) is Sofa.Core.Node:
+#        scn[0] += indent + getAbsPythonCallPath(item.parents[0], prefab) + ".addChild('" + item.getName() + "')\n"
+#    else:
+#        attributes = buildDataParams(item, indent, scn, prefab, external_deps)
+#        parentPath = indent + getAbsPythonCallPath(item.getContext() if type(item) == Sofa.Core.Object else item.parents[0], prefab)
+#        scn[0] += parentPath + ".addObject('" + item.getClassName() + "', name='" + item.getName() + "'" + attributes + ")\n"
+#    return item
+
+#def hasNotYetCreatedDependencies(item, created, prefab=None):
+#    for dep in getDependenciesFor(item):
+#        if dep not in created:
+#            return True
+#    return False
+
+
+#def try_create_dependent_item(node, indent, scn, created, not_created, external_deps = [], prefab = None):
+#    for item in not_created:
+#        if not hasNotYetCreatedDependencies(item, created):
+#            if prefab == None:
+#                created.append(createItem(item, node, indent, scn))
+#            else:
+#                created.append(createItemInPrefab(item, node, indent, scn, external_deps, prefab))
+
+#            not_created.remove(item)
+
+#def r_createNode(node, indent, scn, created, not_created, external_deps = [], prefab = None):
+#    for o in node.objects:
+#        if not hasNotYetCreatedDependencies(o, created):
+#            if prefab == None:
+#                created.append(createItem(o, node, indent, scn))
+#            else:
+#                created.append(createItemInPrefab(o, node, indent, scn, external_deps, prefab))
+#        else:
+#            scn[0] += indent + "# " + o.getName() + " (" + o.getClassName() + ") will be created later because of upstream dependencies\n"
+#            not_created.append(o)
+#    # Deal with components having a dependency to a component located within the same node
+#    try_create_dependent_item(node, indent, scn, created, not_created)
+#    for c in node.children:
+#        scn[0] += "\n"
+#        if prefab == None:
+#            created.append(createItem(c, node, indent, scn))
+#        else:
+#            created.append(createItemInPrefab(c, node, indent, scn, external_deps, prefab))
+#        r_createNode(c, indent, scn, created, not_created, external_deps, prefab)
+#        # Deal with components having a dependency to upstream-located or sibling-located components
+#        try_create_dependent_item(node, indent, scn, created, not_created, external_deps, prefab)
+
+
+#def saveScene(node, indent, scn):
+#    created = [node]
+#    not_created = []
+#    r_createNode(node, indent, scn, created, not_created)
+
+
+
+
+
+
+
+
+
+#def getExternalDependencyFromItem(prefab, item, list):
+#    for d in item.getDataFields():
+#        if d.hasParent() and not d.getParent().getPathName().startswith(prefab.getPathName()):
+#            list.append(d)
+#    for l in item.getLinks():
+#        if l.getLinkedBase() != None and not l.getLinkedBase().getPathName().startswith(prefab.getPathName()) and l.getName() != "parents":
+#            list.append(l)
+
+#def r_getExternalDependencies(prefab, currentNode, list):
+#    getExternalDependencyFromItem(prefab, currentNode, list)
+
+#    for o in currentNode.objects:
+#        getExternalDependencyFromItem(prefab, o, list)
+
+#    for c in currentNode.children:
+#        r_getExternalDependencies(prefab, c, list)
+
+
+#def getParameterName(param, prefab):
+#    return param.getPathName().replace(prefab.getPathName(), "").replace("/", "_").replace(".", "_")[1:]
+
+
+#def writeExternalDependencies(external_deps, prefab, indent):
+#    str = ''
+#    for item in external_deps:
+#        itemName = getParameterName(item, prefab)
+#        if item is Sofa.Core.Data:
+#            str += indent + "self.addPrefabParameter(name='" + itemName + "', type='" + item.typeName() + "')\n"
+#        else:
+#            str += indent + "self.addPrefabParameter(name='" + itemName + "', type='Link', help='" + item.getHelp()  + "')\n"
+#    return str
+
+
+#def r_createPrefab(node, indent, scn, created, not_created, external_deps, prefab):
+#    for o in node.objects:
+#        print("##########################" + o.getName() + "###################")
+#        if not hasNotYetCreatedDependencies(o, created):
+#            created.append(createItemInPrefab(o, node, indent, scn, external_deps, prefab))
+#        else:
+#            print("postpone creation of " + o.getName() + " because of deps")
+#            scn[0] += indent + "# " + o.getName() + " (" + o.getClassName() + ") will be created later because of upstream dependencies\n"
+#            not_created.append(o)
+#    # Deal with components having a dependency to a component located within the same node
+#    try_create_dependent_item(node, indent, scn, created, not_created)
+#    for c in node.children:
+#        scn[0] += "\n"
+#        created.append(createItemInPrefab(c, node, indent, scn, external_deps, prefab))
+#        r_createNode(c, indent, scn, created, not_created, external_deps, prefab)
+#        # Deal with components having a dependency to upstream-located or sibling-located components
+#        try_create_dependent_item(node, indent, scn, created, not_created)
+
+
+#def addExternalDepsCheck(fd, external_deps, prefab):
+#    fd.write("        if ")
+#    first = True
+#    for item in external_deps:
+#        if not first:
+#            fd.write(" or ")
+#        first = False
+#        itemName = getParameterName(item, prefab)
+#        fd.write("not self.findData('"+ itemName +"')")
+#    fd.write(':\n            return\n')
+
+#def createPrefab(fileName, prefab, name, help):
+#    external_deps = []
+#    r_getExternalDependencies(prefab, prefab, external_deps)
+
+#    print('Saving prefab in ' + fileName)
+#    fd = open(fileName, "w+")
+#    fd.write('"""type: SofaContent"""\n')
+#    fd.write("import sys\n")
+#    fd.write("import os\n")
+#    fd.write("import Sofa\n")
+#    fd.write("import Sofa.Core\n")
+
+#    modules = []
+#    modulepaths = []
+#    scn = [""]
+#    nodeName = prefab.getName()
+#    print(prefab.name)
+#    prefab.setName("self")
+#    print(nodeName)
+
+
+#    fd.write("# all Paths\n")
+#    for p in list(dict.fromkeys(modulepaths)):
+#        fd.write("sys.path.append('" + getRelPath(p, fileName) + "')\n")
+
+#    fd.write('# all Modules:\n')
+#    for m in list(dict.fromkeys(modules)):
+#        fd.write("from " + m + " import *\n")
+
+#    fd.write("class " + name + "(Sofa.Prefab):\n")
+#    fd.write("    \"\"\" " + help + " \"\"\"\n")
+#    fd.write("    def __init__(self, *args, **kwargs):\n")
+#    fd.write("        Sofa.Prefab.__init__(self, *args, **kwargs)\n")
+
+
+#    fd.write("        # external deps: " + ", ".join(dep.getName() for dep in external_deps) + "\n")
+
+#    str = writeExternalDependencies(external_deps, prefab, "        ")
+#    fd.write(str)
+
+#    created = [prefab]
+#    not_created = []
+
+#    fd.write("\n\n    def doReInit(self):\n")
+
+#    addExternalDepsCheck(fd, external_deps, prefab)
+
+#    r_createPrefab(prefab, "        ", scn, created + external_deps, not_created, external_deps, prefab)
+#    fd.write(scn[0])
+#    prefab.setName(nodeName)
+
+
+
+
+
+
+#def saveScene(node, indent, scn):
+
+def saveAsPythonPrefab(fileName, prefab, name, help):
+    serializer = GraphSerializer(fileName)
+    serializer.save(prefab, name, help, True)
 
 
 def saveAsPythonScene(fileName, node):
-    root = node
-    fd = open(fileName, "w+")
-
-    fd.write('""" type: SofaContent """\n')
-    fd.write("import sys\n")
-    fd.write("import os\n")
-
-    modules = []
-    modulepaths = []
-    scn = [""]
-    saveScene(node, "    ", scn)
-
-    #    saveRec(root, "    ", modules, modulepaths, scn, root)
-
-    fd.write("# all Paths\n")
-    for p in list(dict.fromkeys(modulepaths)):
-        if p != "":
-            fd.write("sys.path.append('" + getRelPath(p, fileName) +
-                     "')\n")
-
-    fd.write('# all Modules:\n')
-    for m in list(dict.fromkeys(modules)):
-        fd.write("from " + m + " import *\n")
-
-    fd.write("\n\ndef createScene("+ node.getName() +"):\n")
-    fd.write(scn[0])
-    return True
+    serializer = GraphSerializer(fileName)
+    serializer.save(node)
 
 
-def callFunction(file, function, *args, **kwargs):
-    # First let's load that script:
-    importlib.invalidate_caches()
-
-    moduledir = os.path.dirname(file)
-    modulename = os.path.basename(file)
-    spec = importlib.util.spec_from_file_location(modulename, moduledir+"/"+modulename)
-    m = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(m)
-    return getattr(m, function)(*args, **kwargs)
 
 
-def createTypeConversionEngine(modulename, node, srcData, dstData, srcType, dstType):
-    engineName = "to_"+dstData.getOwner().getName() + "_" + dstData.getName()
-    if engineName not in node.objects:
-        m = importlib.import_module(modulename)
-        e = splib.TypeConversionEngine(name=engineName, dstType=dstData.typeName())
-        dstData.setParent(e.dst)
-        node.addObject(e)
-    e.addDataConversion(srcData, m.convert)
 
 
-def createPrefabFromNode(fileName, node, name, help):
-    print('Saving prefab in ' + fileName)
-    fd = open(fileName, "w+")
-    fd.write('"""type: SofaContent"""\n')
-    fd.write("import sys\n")
-    fd.write("import os\n")
-    fd.write("import Sofa\n")
-    fd.write("import Sofa.Core\n")
-
-    modules = []
-    modulepaths = []
-    scn = [""]
-    nodeName = node.getName()
-    print(node.name)
-    node.setName("self")
-    print(nodeName)
-    saveRec(node, "        ", modules, modulepaths, scn, node)
-    print("saved rec")
-    node.setName(nodeName)
-    print(node.name)
-
-    fd.write("# all Paths\n")
-    for p in list(dict.fromkeys(modulepaths)):
-        fd.write("sys.path.append('" + getRelPath(p, fileName) + "')\n")
-
-    fd.write('# all Modules:\n')
-    for m in list(dict.fromkeys(modules)):
-        fd.write("from " + m + " import *\n")
-
-    fd.write("class " + name + "(Sofa.Prefab):\n")
-    fd.write("    \"\"\" " + help + " \"\"\"\n")
-    fd.write("    def __init__(self, *args, **kwargs):\n")
-    fd.write("        Sofa.Prefab.__init__(self, *args, **kwargs)\n")
-    fd.write(scn[0])
-    return True
 
 
-def getPrefabMetaData(func, node):
-    """ Retreives all meta data from a python function and stores it as datafields in the given node """
-    inspect = importlib.import_module("inspect")
-    f = func.__init__ if inspect.isclass(func) else func
-    node.addData(name="modulename", value=inspect.getmodulename(f.__code__.co_filename), type="string", help="module containing the prefab", group="Infos")
-    node.addData(name="prefabname", value=f.__code__.co_name, type="string", help="prefab's function name", group="Infos")
-    node.addData(name="modulepath", value=f.__code__.co_filename, type="string", help="module path for this prefab", group="Infos")
-    node.addData(name="lineno", value=f.__code__.co_firstlineno, type="int", help="first line number of the prefab in the module", group="Infos")
-    node.addData(name="sourcecode", value=inspect.getsource(func), type="string", help="The prefab's source code", group="Infos")
-    node.addData(name="docstring", value=func.__doc__, type="string", help="The prefab's docstring", group="Infos")
-    return node
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#def saveAsPythonScene(fileName, node):
+#    root = node
+#    fd = open(fileName, "w+")
+
+#    fd.write('""" type: SofaContent """\n')
+#    fd.write("import sys\n")
+#    fd.write("import os\n")
+
+#    modules = []
+#    modulepaths = []
+#    scn = [""]
+#    saveScene(node, "    ", scn)
+
+#    #    saveRec(root, "    ", modules, modulepaths, scn, root)
+
+#    fd.write("# all Paths\n")
+#    for p in list(dict.fromkeys(modulepaths)):
+#        if p != "":
+#            fd.write("sys.path.append('" + getRelPath(p, fileName) +
+#                     "')\n")
+
+#    fd.write('# all Modules:\n')
+#    for m in list(dict.fromkeys(modules)):
+#        fd.write("from " + m + " import *\n")
+
+#    fd.write("\n\ndef createScene("+ node.getName() +"):\n")
+#    fd.write(scn[0])
+#    return True
+
+
+#def callFunction(file, function, *args, **kwargs):
+#    # First let's load that script:
+#    importlib.invalidate_caches()
+
+#    moduledir = os.path.dirname(file)
+#    modulename = os.path.basename(file)
+#    spec = importlib.util.spec_from_file_location(modulename, moduledir+"/"+modulename)
+#    m = importlib.util.module_from_spec(spec)
+#    spec.loader.exec_module(m)
+#    return getattr(m, function)(*args, **kwargs)
+
+
+#def createTypeConversionEngine(modulename, node, srcData, dstData, srcType, dstType):
+#    engineName = "to_"+dstData.getOwner().getName() + "_" + dstData.getName()
+#    if engineName not in node.objects:
+#        m = importlib.import_module(modulename)
+#        e = splib.TypeConversionEngine(name=engineName, dstType=dstData.typeName())
+#        dstData.setParent(e.dst)
+#        node.addObject(e)
+#    e.addDataConversion(srcData, m.convert)
+
+
+#def createPrefabFromNode(fileName, node, name, help):
+#    print('Saving prefab in ' + fileName)
+#    fd = open(fileName, "w+")
+#    fd.write('"""type: SofaContent"""\n')
+#    fd.write("import sys\n")
+#    fd.write("import os\n")
+#    fd.write("import Sofa\n")
+#    fd.write("import Sofa.Core\n")
+
+#    modules = []
+#    modulepaths = []
+#    scn = [""]
+#    nodeName = node.getName()
+#    print(node.name)
+#    node.setName("self")
+#    print(nodeName)
+#    saveRec(node, "        ", modules, modulepaths, scn, node)
+#    print("saved rec")
+#    node.setName(nodeName)
+#    print(node.name)
+
+#    fd.write("# all Paths\n")
+#    for p in list(dict.fromkeys(modulepaths)):
+#        fd.write("sys.path.append('" + getRelPath(p, fileName) + "')\n")
+
+#    fd.write('# all Modules:\n')
+#    for m in list(dict.fromkeys(modules)):
+#        fd.write("from " + m + " import *\n")
+
+#    fd.write("class " + name + "(Sofa.Prefab):\n")
+#    fd.write("    \"\"\" " + help + " \"\"\"\n")
+#    fd.write("    def __init__(self, *args, **kwargs):\n")
+#    fd.write("        Sofa.Prefab.__init__(self, *args, **kwargs)\n")
+#    fd.write(scn[0])
+#    return True
+
+
+#def getPrefabMetaData(func, node):
+#    """ Retreives all meta data from a python function and stores it as datafields in the given node """
+#    inspect = importlib.import_module("inspect")
+#    f = func.__init__ if inspect.isclass(func) else func
+#    node.addData(name="modulename", value=inspect.getmodulename(f.__code__.co_filename), type="string", help="module containing the prefab", group="Infos")
+#    node.addData(name="prefabname", value=f.__code__.co_name, type="string", help="prefab's function name", group="Infos")
+#    node.addData(name="modulepath", value=f.__code__.co_filename, type="string", help="module path for this prefab", group="Infos")
+#    node.addData(name="lineno", value=f.__code__.co_firstlineno, type="int", help="first line number of the prefab in the module", group="Infos")
+#    node.addData(name="sourcecode", value=inspect.getsource(func), type="string", help="The prefab's source code", group="Infos")
+#    node.addData(name="docstring", value=func.__doc__, type="string", help="The prefab's docstring", group="Infos")
+#    return node
 
 
 

--- a/applications-dev/plugins/SofaQtQuickGUI/data/python/SofaQtQuick.py
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/python/SofaQtQuick.py
@@ -145,7 +145,7 @@ def buildDataParams(obj, indent, scn, prefab=None, external_deps=[]):
                                 s += ", " + data.getName() + "=" + ( v[v.find('['):v.rfind(']')+1] if "array" in repr(data.value) else repr(data.value))
     for link in links:
         if link in external_deps and prefab != None:
-            s += ", " + link.getName() + "=" + "self." + getParameterName(link, prefab)
+            s += ", " + link.getName() + "=" + "self." + getParameterName(link, prefab) + ".value"
 
         elif link.getLinkedBase() and link.getName() != "context":
             s += ", " + link.getName() + "='" + link.getLinkedPath() + "'"
@@ -315,9 +315,9 @@ def writeExternalDependencies(external_deps, prefab, indent):
     for item in external_deps:
         itemName = getParameterName(item, prefab)
         if item is Sofa.Core.Data:
-            str += indent + "self.addData(name='" + itemName + "', type='" + item.typeName() + "')\n"
+            str += indent + "self.addDataParameter(name='" + itemName + "', type='" + item.typeName() + "')\n"
         else:
-            str += indent + "self.addLink(name='" + itemName + "')\n"
+            str += indent + "self.addLinkParameter(name='" + itemName + "', help='" + item.getHelp()  + "')\n"
     return str
 
 

--- a/applications-dev/plugins/SofaQtQuickGUI/data/python/graph_serialization.py
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/python/graph_serialization.py
@@ -1,0 +1,301 @@
+import os
+import Sofa.Core
+
+
+class GraphSerializer:
+    def __init__(self, filename):
+        self.filename = filename
+
+
+    def save(self, node, name = "", help = "", is_prefab = False):
+        self.node = node
+        self.name = name if name else node.getName()
+        self.help = help
+        self.is_prefab = is_prefab
+        with open(self.filename, 'w') as fd:
+            self.write_header(fd)
+            self.write_import_statements(fd)
+
+            self.get_external_dependencies()
+            self.write_definition(fd)
+
+            if self.is_prefab:
+                nodeName = self.node.getName()
+                self.node.setName("self")
+
+                self.write_prefab_parameters(fd)
+
+                fd.write("\n\n    def doReInit(self):\n")
+                self.createGraph(fd)
+
+                self.node.setName(nodeName)
+            else:
+                self.createGraph(fd)
+
+
+    def getParameterName(self, param):
+        return param.getPathName().replace(self.node.getPathName(), "").replace("/", "_").replace(".", "_")[1:]
+
+
+    def write_prefab_parameters(self, fd):
+        fd.write("        # external deps: " + ", ".join(dep.getName() for dep in self.external_deps) + "\n")
+        str = ''
+        for item in self.external_deps:
+            itemName = self.getParameterName(item)
+            if item is Sofa.Core.Data:
+                fd.write("        self.addPrefabParameter(name='" + itemName + "', type='" + item.typeName() + "')\n")
+            else:
+                fd.write("        self.addPrefabParameter(name='" + itemName + "', type='Link', help='" + item.getHelp()  + "')\n")
+
+
+    def write_definition(self, fd):
+        if self.is_prefab:
+            fd.write("\n\nclass " + self.name + "(Sofa.Prefab):\n")
+            fd.write("    \"\"\" " + self.help + " \"\"\"\n")
+            fd.write("    def __init__(self, *args, **kwargs):\n")
+            fd.write("        Sofa.Prefab.__init__(self, *args, **kwargs)\n")
+        else:
+            fd.write("\n\ndef createScene(root):\n")
+            fd.write('    """ ' + self.help + ' """\n')
+
+    def get_external_dependencies(self):
+        self.external_deps = []
+        """ writes into self.external_deps all dependencies to potential objects external to self.node """
+        def getExternalDependencyFromItem(item):
+            for d in item.getDataFields():
+                if d.hasParent() and not d.getParent().getPathName().startswith(self.node.getPathName()):
+                    self.external_deps.append(d)
+            for l in item.getLinks():
+                if l.getLinkedBase() is not None and not l.getLinkedBase().getPathName().startswith(self.node.getPathName()) and l.getName() != "parents":
+                    self.external_deps.append(l)
+
+        def r_getExternalDependencies(currentNode):
+            getExternalDependencyFromItem(currentNode)
+
+            for o in currentNode.objects:
+                getExternalDependencyFromItem(o)
+
+            for c in currentNode.children:
+                r_getExternalDependencies(c)
+
+        r_getExternalDependencies(self.node)
+
+
+    def write_header(self, fd):
+        fd.write('"""type: SofaContent"""\n')
+
+
+    def getRelPath(path, relativeTo):
+        """
+        returns `path`, expressed relatively to `relativeTo`. For instance:
+        path =       /home/bruno/dev/myproject/scripts
+        relativeTo = /home/bruno/dev/myproject/scenes/MyCoolFile.py
+        return "../scripts/"
+        """
+        if os.path.isfile(relativeTo):
+            relativeTo = os.path.dirname(relativeTo)
+
+        if path == relativeTo:
+            return ""
+        commonPrefix = os.path.commonprefix([path, relativeTo])
+        path = path.replace(commonPrefix, "")  # /scripts
+        if path.startswith('/'):
+            path = path[1:]  # scripts
+        relativeTo = relativeTo.replace(commonPrefix, "")  # scenes
+        newPath = ""
+        if relativeTo != "":
+            newPath += "../"
+            for d in relativeTo.split('/'):
+                newPath += "../"
+
+        newPath += path
+        return newPath
+
+
+    def write_import_statements(self, fd):
+        """
+        crawls self.node looking for prefabs, store the module names corresponding to
+        the definition files of those prefabs, and finally write down both the import statements
+        and adding of those modules' directories to sys.path
+        """
+        fd.write("import sys\n")
+        fd.write("import os\n")
+        fd.write("import Sofa.Core\n")
+
+        modules = []
+        module_paths = []
+        def r_write_imports(node):
+            for child in node.children:
+                if child.getData("prefabname") is not None:
+                    dirname, filename = os.path.split(child.getDefinitionSourceFileName())
+                    modules.append(filename)
+                    module_paths.append(dirname)
+                else:
+                    r_write_imports(child)
+
+        r_write_imports(self.node)
+        if len(module_paths) != 0:
+            fd.write("# all paths:\n")
+        for p in module_paths:
+            fd.write("sys.path.append('" + getRelPath(p, self.filename) + "')\n")
+
+        if len(modules) != 0:
+            fd.write("# all modules:\n")
+        for m in modules:
+            fd.write("from " + m + " import *\n")
+
+
+
+
+
+    def buildDataParams(self, fd, obj):
+        """
+        takes an object (node, component, prefab...) and write down
+        the list of attributes (datafields, links, template type) of this object into the returned string.
+        This string can then be used (in createItem for instance)
+        to serialize a component using the python syntax
+        """
+        s = ""
+        datas = obj.getDataFields()
+        links = obj.getLinks()
+        for data in datas:
+            if data.hasParent():
+                if self.is_prefab and data in self.external_deps:
+                    fd.write("        ### THERE WAS A LINK. ")
+                    fd.write(data.getParent().getLinkPath() + "=>" + data.getLinkPath() + "\n")
+                    if data.getName() != "name":
+                        relPath = os.path.relpath(data.getParent().getPathName(), data.getOwner().getContext().getPathName())
+                        s += ", " + data.getName()+ "='@" + relPath +"'"
+                else:
+                    fd.write("        ### THERE WAS A LINK. ")
+                    fd.write(self.node.getPathName() + "." + self.getParameterName(data) + "=>" + data.getLinkPath() + "\n")
+                    if data.getName() != "name":
+                        relPath = os.path.relpath(self.node.getPathName(), data.getOwner().getContext().getPathName())
+                        s += ", " + data.getName()+ "='@" + relPath +"'"
+            else:
+                if data.getName() not in ["name","prefabname", "docstring"] and (data.isPersistent() or data.isRequired()):
+                    if " " not in data.getName() and data.getName() != "Help":
+                        if data.getName() != "modulepath":
+                            if data.getName() != "depend":
+                                v = repr(data.value)
+                                if "DataFileName" in str(data):
+                                    if os.path.exists(os.path.dirname(SofaApplication.getScene()) + "/" + v[1:-1]):
+                                        # If the path exists & is relative
+                                        s += ", " + data.getName() + "='" + v[1:-1] + "'"
+                                    elif os.path.relpath(v[1:-1], os.path.dirname(SofaApplication.getScene())):
+                                        # If the path can be expressed relative to the scene file:
+                                        s += ", " + data.getName() + "='" + os.path.relpath(v[1:-1], os.path.dirname(SofaApplication.getScene())) + "'"
+                                    else:
+                                        # fallback (relative path, but not relative to scene file)
+                                        s += ", " + data.getName() + "='" + v[1:-1] + "'"
+                                else:
+                                    s += ", " + data.getName() + "=" + ( v[v.find('['):v.rfind(']')+1] if "array" in repr(data.value) else repr(data.value))
+        for link in links:
+            if link in self.external_deps and self.is_prefab:
+                s += ", " + link.getName() + "=" + "self." + self.getParameterName(link, self.node) + ".value"
+
+            elif link.getLinkedBase() and link.getName() != "context":
+                s += ", " + link.getName() + "='" + link.getLinkedPath() + "'"
+
+        entry = Sofa.Core.ObjectFactory.getComponent(obj.getClassName())
+        if entry.defaultTemplate != obj.getTemplateName():
+            s += ", template='" + obj.getTemplateName() + "'"
+        return s
+
+
+    def getAbsPythonCallPath(self, node):
+        """ returns a string corresponding to the call sequence from the top node (e.g. self[Snake.physics.visu.eye])"""
+        if self.node.getPathName() == "/":
+            if node.getPathName() == "/":
+                return self.node.name.value
+            return self.node.name.value + "['" + node.getPathName().replace("/", ".")[1:] + "']"
+        else:
+            return self.node.name.value + "['" + node.getPathName().replace(self.node.getPathName(), "").replace("/", ".")[1:] + "']"
+
+
+    def createItem(self, fd, item):
+        if type(item) is Sofa.Core.Node:
+            fd.write("        " + self.getAbsPythonCallPath(item.parents[0]) + ".addChild('" + item.getName() + "')\n")
+        else:
+            attributes = self.buildDataParams(fd, item)
+            parentPath = "        " + self.getAbsPythonCallPath(item.getContext() if hasattr(item, "getContext") else item.parents[0])
+            fd.write(parentPath + ".addObject('" + item.getClassName() + "', name='" + item.getName() + "'" + attributes + ")\n")
+        return item
+
+    def getDependenciesFor(self, object):
+        if type(object) is Sofa.Core.Node:
+            return object.parents
+        list = []
+        for d in object.getDataFields():
+            if d.getParent() and type(d.getParent().getOwner()) != Sofa.Core.Node:
+                list.append(d.getParent().getOwner())
+
+        for l in object.getLinks():
+            if l.getLinkedBase() and type(l.getLinkedBase()) != Sofa.Core.Node and l.getName() != "slaves":
+                list.append(l.getLinkedBase())
+
+        list.append(object.getContext())
+        return list
+
+    def hasNotYetCreatedDependencies(self, item, created):
+        for dep in self.getDependenciesFor(item):
+            if dep not in created:
+                return True
+        return False
+
+
+    def try_create_dependent_item(self, fd, item, created, not_created):
+        for o in not_created:
+            if not self.hasNotYetCreatedDependencies(o, created):
+                created.append(self.createItem(fd, o))
+                not_created.remove(item)
+
+
+    def createGraph(self, fd):
+        created = [self.node]
+        not_created = []
+
+        def r_createGraph(node):
+            for o in node.objects:
+                if not self.hasNotYetCreatedDependencies(o, created):
+                    created.append(self.createItem(fd, o))
+                else:
+                    fd.write("        # " + o.getName() + " (" + o.getClassName() + ") will be created later because of upstream dependencies\n")
+                    not_created.append(o)
+
+            self.try_create_dependent_item(fd, node, created, not_created)
+            for c in node.children:
+                fd.write("\n")
+                created.append(self.createItem(fd, c))
+                r_createGraph(c)
+                # Deal with components having a dependency to upstream-located or sibling-located components
+                self.try_create_dependent_item(fd, c, created, not_created)
+
+        r_createGraph(self.node)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/CustomInspectorWidgets/CustomInspector.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/CustomInspectorWidgets/CustomInspector.qml
@@ -63,6 +63,11 @@ ColumnLayout {
                                     keys: ["text/plain"]
                                     anchors.fill: parent
                                     onDropped: {
+                                        if (sofaData.getValueType() === "PrefabLink") {
+                                            sofaData.value = "@" + drag.source.item.getPathName()
+                                            return;
+                                        }
+
                                         if (drag.source.item.getPathName() === SofaApplication.selectedComponent.getPathName()) {
                                             console.error("Cannot link datafields to themselves")
                                             return;
@@ -95,6 +100,10 @@ ColumnLayout {
                                 anchors.fill: parent
 
                                 onDropped: {
+                                    if (sofaData.getValueType() === "PrefabLink") {
+                                        sofaData.value = "@" + drag.source.item.getPathName()
+                                        return;
+                                    }
                                     var data = drag.source.item.getData(sofaData.getName())
                                     if (drag.source.item.getPathName() === SofaApplication.selectedComponent.getPathName()) {
                                         console.error("Cannot link datafields to themselves")

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/CustomInspectorWidgets/CustomInspector.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/CustomInspectorWidgets/CustomInspector.qml
@@ -164,11 +164,21 @@ ColumnLayout {
                         elide: Text.ElideRight
                     }
                     TextField {
+                        id: link_txtfield
                         Layout.fillWidth: true
                         Layout.fillHeight: true
                         readOnly: true
 
                         text: component.findLink(modelData).getLinkedPath().trim()
+                        DropArea {
+                            id: link_dropArea1
+                            anchors.fill: parent
+
+                            onDropped: {
+                                component.findLink(modelData).setLinkedBase(drag.source.item)
+                                link_txtfield.text = Qt.binding(function(){ return component.findLink(modelData).getLinkedPath().trim() })
+                            }
+                        }
                     }
                     Rectangle {
                         color: "transparent"

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/CustomInspectorWidgets/CustomInspector.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/CustomInspectorWidgets/CustomInspector.qml
@@ -45,7 +45,7 @@ ColumnLayout {
                             Layout.maximumWidth: root.labelWidth
 
                             text:  modelData
-                            color: sofaDataLayout.sofaData.properties.required ? "red" : "black"
+                            color: sofaDataLayout.sofaData.properties.required && !sofaDataLayout.sofaData.properties.set ? "red" : "black"
                             elide: Text.ElideRight
                             ToolTip {
                                 text: sofaDataLayout.sofaData.getName()

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/CustomInspectorWidgets/CustomInspector.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/CustomInspectorWidgets/CustomInspector.qml
@@ -3,8 +3,7 @@ import QtQuick.Controls 2.5
 import QtQuick.Layouts 1.3
 import SofaApplication 1.0
 import SofaBasics 1.0
-
-
+import SofaLinkCompletionModel 1.0
 
 
 ColumnLayout {
@@ -111,7 +110,6 @@ ColumnLayout {
                                     }
 
                                     if (data !== null) {
-                                        print("DropArea2")
                                         sofaData.setValue(data.value)
                                         sofaData.setParent(data)
                                     }
@@ -173,10 +171,10 @@ ColumnLayout {
                         elide: Text.ElideRight
                     }
                     TextField {
-                        id: link_txtfield
+                        id: txtField
                         Layout.fillWidth: true
                         Layout.fillHeight: true
-                        readOnly: true
+                        readOnly: false
 
                         text: component.findLink(modelData).getLinkedPath().trim()
                         DropArea {
@@ -185,8 +183,15 @@ ColumnLayout {
 
                             onDropped: {
                                 component.findLink(modelData).setLinkedBase(drag.source.item)
-                                link_txtfield.text = Qt.binding(function(){ return component.findLink(modelData).getLinkedPath().trim() })
+                                txtField.text = Qt.binding(function(){ return component.findLink(modelData).getLinkedPath().trim() })
                             }
+                        }
+                        onEditingFinished: {
+                            component.findLink(modelData).setLinkedPath(text)
+                            focus = false
+                        }
+                        onTextEdited: {
+                            component.findLink(modelData).setLinkedPath(text)
                         }
                     }
                     Rectangle {
@@ -200,7 +205,6 @@ ColumnLayout {
                 }
             }
         }
-
     }
     GroupBox {
         title: "Infos"

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_PrefabLink.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_PrefabLink.qml
@@ -1,0 +1,61 @@
+/*
+Copyright 2015, Anatoscope
+
+This file is part of sofaqtquick.
+
+sofaqtquick is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+sofaqtquick is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import QtQuick 2.0
+import QtQuick.Controls 2.4
+import QtQuick.Layouts 1.3
+import SofaBasics 1.0
+
+/***************************************************************************************************
+  *
+  * A widget dedicated to edit Data<string> object.
+  *
+  *************************************************************************************************/
+TextField {
+    id: root
+
+    property var sofaData: null
+    readOnly: false
+    implicitWidth: parent.width
+    Layout.fillWidth: true
+    selectByMouse: true
+
+    text: sofaData.value.toString()
+    Connections
+    {
+        target: sofaData
+        onValueChanged: {
+            text=sofaData.value.toString()
+            console.log("VALUE HAS CHANGED... "+ text)
+        }
+    }
+
+    onAccepted:
+    {
+        console.log("VALUE HAS CHANGED... SETTING" +  text)
+        sofaData.value = text
+        root.focus = false
+    }
+    onEditingFinished:
+    {
+        console.log("VALUE HAS CHANGED... SETTING2" + text)
+        sofaData.value = text
+        root.focus = false
+    }
+}

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_PrefabLink.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_PrefabLink.qml
@@ -42,19 +42,16 @@ TextField {
         target: sofaData
         onValueChanged: {
             text=sofaData.value.toString()
-            console.log("VALUE HAS CHANGED... "+ text)
         }
     }
 
     onAccepted:
     {
-        console.log("VALUE HAS CHANGED... SETTING" +  text)
         sofaData.value = text
         root.focus = false
     }
     onEditingFinished:
     {
-        console.log("VALUE HAS CHANGED... SETTING2" + text)
         sofaData.value = text
         root.focus = false
     }

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_PrefabLink.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_PrefabLink.qml
@@ -17,42 +17,149 @@ You should have received a copy of the GNU General Public License
 along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import QtQuick 2.0
+import QtQuick 2.12
 import QtQuick.Controls 2.4
 import QtQuick.Layouts 1.3
 import SofaBasics 1.0
+import SofaLinkCompletionModel 1.0
 
 /***************************************************************************************************
   *
   * A widget dedicated to edit Data<string> object.
   *
   *************************************************************************************************/
-TextField {
+RowLayout {
     id: root
-
     property var sofaData: null
-    readOnly: false
-    implicitWidth: parent.width
-    Layout.fillWidth: true
-    selectByMouse: true
 
-    text: sofaData.value.toString()
-    Connections
-    {
-        target: sofaData
-        onValueChanged: {
-            text=sofaData.value.toString()
+    property alias text: txtField.text
+    TextField {
+        id: txtField
+
+        readOnly: false
+        implicitWidth: parent.width
+        Layout.fillWidth: true
+        selectByMouse: true
+
+        placeholderText: root.sofaData ? "Link: @./path/linked_component" : root.sofaData.value.toString()
+        placeholderTextColor: "gray"
+        font.family: "Helvetica"
+        font.weight: Font.Thin
+        clip: true
+        borderColor: 0 === root.sofaData.value.toString().length ? "red" : "#393939"
+
+        text: root.sofaData.value.toString()
+        Keys.forwardTo: [listView.currentItem, listView]
+        Connections
+        {
+            target: root.sofaData
+            onValueChanged: {
+                text=root.sofaData.value.toString()
+            }
+        }
+
+        onEditingFinished: {
+            if (!listView.currentItem) {
+                borderColor = "#393939"
+                focus = false
+                return;
+            }
+
+            root.sofaData.value = listView.currentItem.text
+
+            borderColor = "#393939"
+            focus = false
+        }
+        onTextEdited: {
+            sofaData.value = text
+
+            if (listView.currentIndex >= completionModel.rowCount())
+                listView.currentIndex = 0
+            completionModel.linkPath = text
         }
     }
+    Popup {
+        id: popup
+        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+        visible: txtField.activeFocus
+        padding: 0
+        margins: 0
+        implicitWidth: txtField.width
+        implicitHeight: contentHeight
+        contentWidth: txtField.width - padding
+        contentHeight: listView.implicitHeight < 20 ? 20 : listView.implicitHeight
+        y: 20
 
-    onAccepted:
-    {
-        sofaData.value = text
-        root.focus = false
-    }
-    onEditingFinished:
-    {
-        sofaData.value = text
-        root.focus = false
+        ListView {
+            id: listView
+            visible: txtField.activeFocus
+            anchors.fill: parent
+            currentIndex: 0
+            keyNavigationEnabled: true
+            model: SofaLinkCompletionModel {
+                id: completionModel
+                isComponent: true
+                sofaData: root.sofaData
+                onModelReset: {
+                    listView.implicitHeight = completionModel.rowCount() * 20
+                    parent.contentHeight = completionModel.rowCount() * 20
+                    parent.height = parent.contentHeight
+                }
+            }
+            Keys.onTabPressed: {
+                console.log("TAB pressed (in listView)")
+                txtField.text = listView.currentItem.text
+            }
+
+            Keys.onDownPressed: {
+                currentIndex++
+                if (currentIndex >= listView.rowCount)
+                    currentIndex = listView.rowCount - 1
+            }
+
+            delegate: Rectangle {
+                id: delegateId
+                property Gradient highlightcolor: Gradient {
+                    GradientStop { position: 0.0; color: "#7aa3e5" }
+                    GradientStop { position: 1.0; color: "#5680c1" }
+                }
+                property Gradient nocolor: Gradient {
+                    GradientStop { position: 0.0; color: "transparent" }
+                    GradientStop { position: 1.0; color: "transparent" }
+                }
+                property var view: listView
+                property alias text: entryText.text
+                width: popup.contentWidth
+                height: 20
+                gradient: view.currentIndex === index ? highlightcolor : nocolor
+                Text {
+                    id: entryText
+                    color: view.currentIndex === index ? "black" : itemMouseArea.containsMouse ? "lightgrey" : "white"
+                    anchors.verticalCenter: parent.verticalCenter
+                    width: popup.contentWidth - x * 2
+                    x: 10
+                    text: "@" + completionModel.linkPath + completion
+                    elide: Qt.ElideLeft
+                    clip: true
+                }
+                ToolTip {
+                    text: name
+                    description: help
+                    visible: itemMouseArea.containsMouse
+                    timeout: 2000
+                }
+                MouseArea {
+                    id: itemMouseArea
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    onClicked: {
+                        view.currentIndex = index
+                        txtField.forceActiveFocus()
+                        txtField.text = "@"+entryText.text
+                    }
+                }
+            }
+
+        }
     }
 }

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_string.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/SofaDataType_string.qml
@@ -42,19 +42,16 @@ TextField {
         target: sofaData
         onValueChanged: {
             text=sofaData.value.toString()
-            console.log("VALUE HAS CHANGED... "+ text)
         }
     }
 
     onAccepted:
     {
-        console.log("VALUE HAS CHANGED... SETTING" +  text)
         sofaData.value = text
         root.focus = false
     }
     onEditingFinished:
     {
-        console.log("VALUE HAS CHANGED... SETTING2" + text)
         sofaData.value = text
         root.focus = false
     }

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/qmldir
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaDataTypes/qmldir
@@ -10,6 +10,7 @@ SofaDataType_OptionsGroup 1.0 SofaDataType_OptionsGroup.qml
 SofaDataType_Material 1.0 SofaDataType_Material.qml
 SofaDataType_poissonRatio.notimplementedyet 1.0 SofaDataType_poissonRatio.notimplementedyet.qml
 SofaDataType_string 1.0 SofaDataType_string.qml
+SofaDataType_PrefabLink 1.0 SofaDataType_PrefabLink.qml
 SofaDataType_widget_displayFlags 1.0 SofaDataType_widget_displayFlags.qml
 SofaDataType_RGBAColor 1.0 SofaDataType_RGBAColor.qml
 SofaDataType_ComponentState 1.0 SofaDataType_ComponentState.qml

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/sofaQtQuickGUI_qml.qrc
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/sofaQtQuickGUI_qml.qrc
@@ -160,5 +160,6 @@
         <file>SofaWidgets/TemplatesPreferences.qml</file>
         <file>SofaBasics/TabView.qml</file>
         <file>SofaDataTypes/ImportFileDialog.qml</file>
+        <file>SofaDataTypes/SofaDataType_PrefabLink.qml</file>
     </qresource>
 </RCC>

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaBase.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaBase.cpp
@@ -290,7 +290,7 @@ void SofaBase::dump() const
 QString SofaBase::componentStateAsString() const
 {
     std::stringstream s;
-    s << rawBase()->d_componentstate.getValue();
+    s << rawBase()->d_componentState.getValue();
     return QString::fromStdString(s.str());
 }
 

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaLink.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaLink.cpp
@@ -70,6 +70,11 @@ SofaBase* SofaLink::getLinkedBase(size_t index)
                                                          "Unable to get SofaBase.");
 }
 
+void SofaLink::setLinkedBase(sofaqtquick::bindings::_sofabase_::SofaBase *linkedbase)
+{
+    m_self->setLinkedBase(linkedbase->rawBase());
+}
+
 SofaData* SofaLink::getLinkedData(size_t index)
 {
     if(index >= m_self->getSize())

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaLink.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaLink.cpp
@@ -75,6 +75,11 @@ void SofaLink::setLinkedBase(sofaqtquick::bindings::_sofabase_::SofaBase *linked
     m_self->setLinkedBase(linkedbase->rawBase());
 }
 
+void SofaLink::setLinkedPath(const QString& path)
+{
+    m_self->read(path.toStdString());
+}
+
 SofaData* SofaLink::getLinkedData(size_t index)
 {
     if(index >= m_self->getSize())

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaLink.h
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaLink.h
@@ -45,6 +45,7 @@ namespace sofaqtquick::bindings
             Q_INVOKABLE unsigned int getSize();
             Q_INVOKABLE SofaBase* getLinkedBase(size_t index = 0);
             Q_INVOKABLE void setLinkedBase(SofaBase* linkedbase);
+            Q_INVOKABLE void setLinkedPath(const QString& str);
             Q_INVOKABLE SofaData* getLinkedData(size_t index = 0);
             Q_INVOKABLE QString   getLinkedPath(size_t index = 0);
 

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaLink.h
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaLink.h
@@ -44,6 +44,7 @@ namespace sofaqtquick::bindings
             /// Returns the number of link in the SofaLink (in case of multilinks)
             Q_INVOKABLE unsigned int getSize();
             Q_INVOKABLE SofaBase* getLinkedBase(size_t index = 0);
+            Q_INVOKABLE void setLinkedBase(SofaBase* linkedbase);
             Q_INVOKABLE SofaData* getLinkedData(size_t index = 0);
             Q_INVOKABLE QString   getLinkedPath(size_t index = 0);
 

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Models/SofaLinkCompletionModel.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Models/SofaLinkCompletionModel.cpp
@@ -9,6 +9,8 @@ using namespace sofa::core::objectmodel;
 
 void SofaLinkCompletionModel::setSofaData(sofaqtquick::bindings::_sofadata_::SofaData *newSofaData)
 {
+    if (!newSofaData) return;
+
     m_sofaData = newSofaData;
     sofa::core::objectmodel::Base* base = newSofaData->rawData()->getOwner();
     m_relativeRoot = base->toBaseNode();
@@ -102,6 +104,7 @@ Base* SofaLinkCompletionModel::getLastValidObject(QString& lastValidLinkPath)
 
 void SofaLinkCompletionModel::updateModel()
 {
+    if (!m_sofaData) return;
     beginResetModel();
     QString lastValidLinkPath = "";
     std::string path_separator = "/";
@@ -112,9 +115,9 @@ void SofaLinkCompletionModel::updateModel()
         path_separator = "";
         data_separator = "";
     }
-    if (lastValidLinkPath[lastValidLinkPath.size() -1] == "/")
+    else if (lastValidLinkPath[lastValidLinkPath.size() -1] == "/")
         path_separator = "";
-    if (lastValidLinkPath[lastValidLinkPath.size() -1] == ".")
+    else if (lastValidLinkPath[lastValidLinkPath.size() -1] == ".")
         data_separator = "";
     m_modelText.clear();
     m_modelName.clear();
@@ -124,6 +127,7 @@ void SofaLinkCompletionModel::updateModel()
         endResetModel();
         return;
     }
+
     if (lastValid->toBaseNode())
     {
         BaseNode* node = lastValid->toBaseNode();
@@ -144,13 +148,16 @@ void SofaLinkCompletionModel::updateModel()
         }
     }
 
-    for (auto data : lastValid->getDataFields())
+    if (m_isComponent)
     {
-        if (data->getValueTypeString() == sofaData()->rawData()->getValueTypeString())
+        for (auto data : lastValid->getDataFields())
         {
-            m_modelText.push_back(lastValidLinkPath+QString::fromStdString(data_separator+data->getName()));
-            m_modelName.push_back(QString::fromStdString(data->getName()));
-            m_modelHelp.push_back(QString::fromStdString(data->getHelp()));
+            if (data->getValueTypeString() == sofaData()->rawData()->getValueTypeString())
+            {
+                m_modelText.push_back(lastValidLinkPath+QString::fromStdString(data_separator+data->getName()));
+                m_modelName.push_back(QString::fromStdString(data->getName()));
+                m_modelHelp.push_back(QString::fromStdString(data->getHelp()));
+            }
         }
     }
     m_modelText.erase(std::remove_if(m_modelText.begin(), m_modelText.end(),

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Models/SofaLinkCompletionModel.h
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Models/SofaLinkCompletionModel.h
@@ -29,6 +29,11 @@ public:
 
     Q_PROPERTY(sofaqtquick::bindings::SofaData* sofaData READ sofaData WRITE setSofaData NOTIFY sofaDataChanged)
     Q_PROPERTY(QString linkPath READ getLinkPath WRITE setLinkPath NOTIFY linkPathChanged)
+    Q_PROPERTY(bool isComponent READ isComponent WRITE setIsComponent NOTIFY isComponentChanged)
+
+    inline bool isComponent() const { return m_isComponent; }
+    void setIsComponent(bool isComponent) { m_isComponent = isComponent; }
+
 
     inline sofaqtquick::bindings::SofaData* sofaData() const { return m_sofaData; }
     void setSofaData(sofaqtquick::bindings::SofaData* newSofaData);
@@ -39,6 +44,7 @@ public:
 signals:
     void sofaDataChanged(sofaqtquick::bindings::SofaData* newSofaData) const;
     void linkPathChanged(QString newlinkPath) const;
+    void isComponentChanged(bool isComponent) const;
 
 protected:
     int	rowCount(const QModelIndex & parent = QModelIndex()) const;
@@ -48,6 +54,7 @@ protected:
 private:
     sofaqtquick::bindings::SofaData* m_sofaData;
     QString m_linkPath;
+    bool m_isComponent;
 
     QStringList m_modelText;
     QStringList m_modelName;

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Models/SofaSceneItemModel.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Models/SofaSceneItemModel.cpp
@@ -82,7 +82,7 @@ void SofaSceneItemModel::emitAllChanges(Node* node)
 
     for (BaseObject::SPtr object: node->object)
     {
-        if( m_dataTracker.hasChanged(object->m_componentstate) )
+        if( m_dataTracker.hasChanged(object->d_componentState) )
         {
             QModelIndex t = index(node, object.get());
             emit dataChanged(t,t);
@@ -94,7 +94,7 @@ void SofaSceneItemModel::emitAllChanges(Node* node)
         emitAllChanges(child.get());
     }
 
-    if( m_dataTracker.hasChanged(node->m_componentstate) )
+    if( m_dataTracker.hasChanged(node->d_componentState) )
     {
         QModelIndex t = index(node);
         emit dataChanged(t,t);
@@ -348,7 +348,7 @@ QVariant SofaSceneItemModel::data(const QModelIndex &index, int role) const
     case Roles::Row:
         return QVariant(index.row());
     case Roles::Status:
-        return QVariant(QString::fromStdString(currentBase->d_componentstate.getValueString()));
+        return QVariant(QString::fromStdString(currentBase->d_componentState.getValueString()));
     }
 
     return QVariant(QString("INVALID ROLE"));

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/QMLUI/QMLUI.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/QMLUI/QMLUI.cpp
@@ -51,9 +51,9 @@ void QmlUILoader::resetAndLoadAll(QList<QObject*> list)
 
 void QmlUILoader::load(SofaBaseObject* canvas)
 {
-    std::cout << "loading canvas " << canvas->getName() << ". Status: " << canvas->self()->m_componentstate << std::endl;
-    if (canvas->self()->m_componentstate == sofa::core::objectmodel::ComponentState::Loading ||
-            canvas->self()->m_componentstate == sofa::core::objectmodel::ComponentState::Invalid)
+    std::cout << "loading canvas " << canvas->getName() << ". Status: " << canvas->self()->d_componentState.getValue() << std::endl;
+    if (canvas->self()->d_componentState.getValue() == sofa::core::objectmodel::ComponentState::Loading ||
+            canvas->self()->d_componentState.getValue() == sofa::core::objectmodel::ComponentState::Invalid)
         canvas->init();
     QQmlEngine* engine = qmlEngine(this);
     if(!engine)

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaBaseApplication.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaBaseApplication.cpp
@@ -25,6 +25,7 @@ along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
 #include <SofaQtQuickGUI/ProcessState.h>
 
 #include <sofa/helper/system/FileSystem.h>
+#include <sofa/helper/system/PluginManager.h>
 #include <sofa/helper/system/FileRepository.h>
 #include <sofa/helper/Utils.h>
 #include <sofa/helper/BackTrace.h>
@@ -1251,6 +1252,8 @@ sofaqtquick::bindings::SofaBase* SofaBaseApplication::GetSelectedComponent()
 
 bool SofaBaseApplication::DefaultMain(QApplication& app, QQmlApplicationEngine &applicationEngine, const QString& mainScript)
 {
+    sofa::helper::system::PluginManager::getInstance().loadPluginByName("SofaPython3");
+
     OurInstance = new SofaBaseApplication();
 
     // color console

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaProject.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaProject.cpp
@@ -544,7 +544,7 @@ bool SofaProject::createPrefab(SofaBase* node)
             py::module::import("Sofa.Core");
             py::object rootNode = sofapython3::PythonFactory::toPython(node->base()->toBaseNode());
             py::module m = py::module::import("SofaQtQuick");
-            return py::cast<bool>(m.attr("createPrefab")(fileName, rootNode, name.toStdString(), help.toStdString()));
+            return py::cast<bool>(m.attr("saveAsPythonPrefab")(fileName, rootNode, name.toStdString(), help.toStdString()));
         }
     }
     return false;

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaProject.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaProject.cpp
@@ -544,7 +544,7 @@ bool SofaProject::createPrefab(SofaBase* node)
             py::module::import("Sofa.Core");
             py::object rootNode = sofapython3::PythonFactory::toPython(node->base()->toBaseNode());
             py::module m = py::module::import("SofaQtQuick");
-            return py::cast<bool>(m.attr("createPrefabFromNode")(fileName, rootNode, name.toStdString(), help.toStdString()));
+            return py::cast<bool>(m.attr("createPrefab")(fileName, rootNode, name.toStdString(), help.toStdString()));
         }
     }
     return false;

--- a/applications-dev/projects/runSofa2/CMakeLists.txt
+++ b/applications-dev/projects/runSofa2/CMakeLists.txt
@@ -62,13 +62,17 @@ list(APPEND QML_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../")
 set(QML_IMPORT_PATH "${QML_IMPORT_PATH};${QML_DIRS}" CACHE STRING "Qt Creator extra qml import paths" FORCE)
 
 set(QMLLIVE_WORKSPACE_PATH \"${CMAKE_CURRENT_LIST_DIR}/../../\")
-configure_file("${PROJECT_NAME}.h.in" "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/${PROJECT_NAME}.h")
-install(FILES "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/${PROJECT_NAME}.h" DESTINATION "include/${PROJECT_NAME}" COMPONENT headers)
+configure_file("${PROJECT_NAME}.h.in" "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/${PROJECT_NAME}/${PROJECT_NAME}.h")
+install(FILES "${CMAKE_BINARY_DIR}/include/${PROJECT_NAME}/${PROJECT_NAME}/${PROJECT_NAME}.h" DESTINATION "include/${PROJECT_NAME}/${PROJECT_NAME}" COMPONENT headers)
 
 add_executable(${PROJECT_NAME} ${HEADER_FILES} ${MOC_FILES} ${SOURCE_FILES} ${QRC_FILES} ${RESOURCE_FILES} ${QML_FILES} ${CONFIG_FILES})
 
 target_link_libraries(${PROJECT_NAME} PUBLIC SofaHelper Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Qml Qt5::Quick Qt5::QuickControls2 Qt5::WebView)
-target_link_libraries(${PROJECT_NAME} PUBLIC SofaQtQuickGUI)
+target_link_libraries(${PROJECT_NAME} PUBLIC SofaQtQuickGUI SofaFramework)
+
+target_include_directories(${PROJECT_NAME} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>")
+target_include_directories(${PROJECT_NAME} PUBLIC "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+
 
 sofa_install_targets(${PROJECT_NAME} ${PROJECT_NAME} "")
 


### PR DESCRIPTION
depends on  [#36](https://github.com/sofa-framework/SofaPython3/pull/36)

Prefabs can now be saved and reused without instantiation errors:

external dependencies are added directly on the Prefab's node, in the "Prefab's parameters" group:
- external data dependencies are added using addDataParameter()
- external link deps (to components) are added using addLinkParameter() which creates a PrefabLink (see SP3 pr #36)
- after properly defining all external dependencies in the \_\_init\_\_ method, doReInit calls the addObject() methods on the prefab to create the graph structure, and instead of linking to external deps directly, it links to the Prefab parameters

In the GUI:
- PrefabLinks appear as if they were DataStrings. On editing, the data field's value changes, which triggers a new call to doReInit, this time instantiating the components requiring external dependencies, if they were properly set.


TODO:
- ~~Create Specific QML widget for SofaDataType_PrefabLink, so that we can add path completion and error mgmt on edits~~
- ~~Prefabs currently crash on first instantation, if external deps are present. That is because the first call to doReInit is triggered from `Sofa.Prefab.__init__` (c++ side) before prefab params were actually defined. thus references to those params lead to attribute error exceptions in python. A simple trick is to set a boolean at the end of \_\_init\_\_ and to check it in doReInit~~:

```py
    def __init__(self, *args, **kwargs):
        Sofa.Prefab.__init__(self, *args, **kwargs)
        # declare prefab params here
        self.is_initialized = True

    def doReInit(self):
        if not self.is_initialized:
            return
        # do stuff here
```

- Detect external usages of components within a prefab, and expose those components as PrefabLinks too from doReInit