### PR TITLE
createFolderIn QML binding fix

### DIFF
--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaApplication/SofaApplication.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaApplication/SofaApplication.qml
@@ -125,6 +125,11 @@ Item //
         return SofaBaseApplicationSingleton.createAssetTemplate(file);
     }
 
+    function createFolderIn(parent)
+    {
+        return SofaBaseApplicationSingleton.createFolderIn(parent);
+    }
+
     /// Returns the absolute position of the mouse in a mouseArea
     /// Takes a MouseArea as argument
     function getAbsolutePosition(node) {


### PR DESCRIPTION
since SofaApplication.qml isn't using SofaBaseApplication through inheritance but composition, a call function had to be added to SofaApplication.qml