### PR TITLE
SelectedComponent unwillingly deleted by QML garbage collector

### DIFF
--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaBase.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaBase.cpp
@@ -65,6 +65,12 @@ SofaBase::SofaBase(const SofaBase& o)
     m_self = o.rawBase();
 }
 
+SofaBase& SofaBase::operator=(const SofaBase& o)
+{
+    m_self = o.rawBase();
+    return *this;
+}
+
 QString SofaBase::getName() const
 {
     return QString::fromStdString(m_self->getName());

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaBase.h
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaBase.h
@@ -49,6 +49,7 @@ class SOFA_SOFAQTQUICKGUI_API SofaBase : public QObject
 public:
     SofaBase(Base::SPtr self);
     SofaBase(const SofaBase& o);
+    SofaBase& operator=(const SofaBase& o);
     ~SofaBase() {}
 
     Q_INVOKABLE QString getName() const;

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SelectableSofaComponent.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SelectableSofaComponent.cpp
@@ -18,6 +18,7 @@ along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include <SofaQtQuickGUI/SelectableSofaComponent.h>
+#include <QQmlEngine>
 
 namespace sofaqtquick
 {
@@ -25,7 +26,7 @@ namespace sofaqtquick
 SelectableSofaComponent::SelectableSofaComponent(sofaqtquick::bindings::SofaBaseObject* sofaComponent) : Selectable(),
     mySofaComponent(sofaComponent)
 {
-
+    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
 }
 
 SelectableSofaComponent::~SelectableSofaComponent()

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaBaseApplication.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaBaseApplication.cpp
@@ -97,7 +97,8 @@ SofaBaseApplication* SofaBaseApplication::OurInstance = nullptr;
 
 SofaBaseApplication::SofaBaseApplication(QObject* parent) : QObject(parent),
     myPythonDirectory(),
-    myDataDirectory()
+    myDataDirectory(),
+    m_selectedComponent(new SofaBase(nullptr))
 {
     OurInstance = this;
 
@@ -1216,28 +1217,21 @@ class UseOpenGLDebugLoggerRunnable : public QRunnable
 
 sofaqtquick::bindings::SofaBase* SofaBaseApplication::getSelectedComponent() const
 {
-    if(m_selectedComponent.get() == nullptr)
+    if(m_selectedComponent->rawBase() == nullptr)
         return nullptr;
-    return new SofaBase(m_selectedComponent.get());
+    return m_selectedComponent;
 }
 
 
 void SofaBaseApplication::setSelectedComponent(sofaqtquick::bindings::SofaBase* selectedComponent)
 {
-    if(selectedComponent == nullptr)
-    {
-        if(m_selectedComponent) {
-            setSelectedComponent(new SofaBase(m_selectedComponent));
-            return;
-        }
-        emit selectedComponentChanged(new SofaBase(m_selectedComponent));
+    if (selectedComponent == nullptr
+        || selectedComponent->rawBase() == nullptr
+        || selectedComponent->rawBase() == m_selectedComponent->rawBase())
         return;
-    }
-
-    if(selectedComponent->rawBase() == m_selectedComponent)
-        return;
-    m_selectedComponent = selectedComponent->rawBase();
-    emit selectedComponentChanged(selectedComponent);
+    m_selectedComponent = selectedComponent;
+    emit selectedComponentChanged(m_selectedComponent);
+    emit signalComponent(m_selectedComponent->getPathName());
 }
 
 void SofaBaseApplication::SetSelectedComponent(sofaqtquick::bindings::SofaBase* selectedComponent)

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaBaseApplication.h
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaBaseApplication.h
@@ -195,7 +195,7 @@ private:
     QString					myPythonDirectory;
     QString                 myDataDirectory;
 
-    sofa::core::objectmodel::Base::SPtr m_selectedComponent;
+    sofaqtquick::bindings::SofaBase* m_selectedComponent;
 
     QTimer m_viewUpdater;
     std::map<QmlDDGNode*, int> m_pendingUpdates;


### PR DESCRIPTION
Long awaited bugfix!
SelectableComponent was responsible for deleting the selectedComponent, dynamically created from c++, returned to QML without proper ownership flag.

This might create a small memory leak as a SofaBase is created upon selection of the component, passed to QML, but never deleted later. 