### PR TITLE
[SofaQtQuickGUI] FIX SofaBaseApplication m_selectedComponent holding a SofaBase pointer

### DIFF
--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaCamera.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaCamera.cpp
@@ -52,19 +52,17 @@ SofaCamera::~SofaCamera()
 
 }
 
-sofaqtquick::bindings::SofaBaseObject* SofaCamera::sofaComponent() const
+sofaqtquick::bindings::SofaBase* SofaCamera::sofaComponent() const
 {
-    return m_sofaComponent;
+    return new SofaBase(m_sofaComponent);
 }
 
-void SofaCamera::setSofaComponent(sofaqtquick::bindings::SofaBaseObject* sofaComponent)
+void SofaCamera::setSofaComponent(sofaqtquick::bindings::SofaBase* sofaComponent)
 {
-    if (sofaComponent == m_sofaComponent)
+    if (sofaComponent->base() == m_sofaComponent)
         return;
 
-    m_sofaComponent = sofaComponent;
-    if (sofaComponent)
-        m_sofaComponent = new sofaqtquick::bindings::SofaBaseObject(*sofaComponent);
+    m_sofaComponent = sofaComponent->base();
 
     sofaComponentChanged();
 }
@@ -80,7 +78,7 @@ void SofaCamera::handleSofaDataChange()
     if (!m_sofaComponent)
         return;
 
-    Base* baseComponent = m_sofaComponent->rawBase();
+    Base* baseComponent = m_sofaComponent.get();
     if (!baseComponent)
         return;
     

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaCamera.h
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Bindings/SofaCamera.h
@@ -49,7 +49,7 @@ class SOFA_SOFAQTQUICKGUI_API SofaCamera : public Camera
 {
     Q_OBJECT
 
-    Q_PROPERTY(sofaqtquick::bindings::SofaBaseObject* sofaComponent READ sofaComponent WRITE setSofaComponent  NOTIFY sofaComponentChanged)
+    Q_PROPERTY(sofaqtquick::bindings::SofaBase* sofaComponent READ sofaComponent WRITE setSofaComponent  NOTIFY sofaComponentChanged)
 
 signals:
     void sofaComponentChanged();
@@ -60,8 +60,8 @@ public:
     explicit SofaCamera(QObject* parent = nullptr);
     ~SofaCamera() override;
 
-    sofaqtquick::bindings::SofaBaseObject* sofaComponent() const;
-    void setSofaComponent(sofaqtquick::bindings::SofaBaseObject* sofaComponent);
+    sofaqtquick::bindings::SofaBase* sofaComponent() const;
+    void setSofaComponent(sofaqtquick::bindings::SofaBase* sofaComponent);
 
     void setBaseCamera(sofa::component::visualmodel::BaseCamera* baseCamera);
     sofa::component::visualmodel::BaseCamera* getBaseCamera(){ return m_baseCamera; }
@@ -120,7 +120,7 @@ public:
         return nullptr;
     }
 private:
-    sofaqtquick::bindings::SofaBaseObject* m_sofaComponent {nullptr};
+    sofa::core::objectmodel::Base::SPtr m_sofaComponent {nullptr};
     mutable sofa::component::visualmodel::BaseCamera* m_baseCamera {nullptr};
 };
 

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SelectableSofaComponent.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SelectableSofaComponent.cpp
@@ -26,7 +26,6 @@ namespace sofaqtquick
 SelectableSofaComponent::SelectableSofaComponent(sofaqtquick::bindings::SofaBaseObject* sofaComponent) : Selectable(),
     mySofaComponent(sofaComponent)
 {
-    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
 }
 
 SelectableSofaComponent::~SelectableSofaComponent()

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaBaseApplication.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaBaseApplication.cpp
@@ -1217,7 +1217,7 @@ class UseOpenGLDebugLoggerRunnable : public QRunnable
 
 sofaqtquick::bindings::SofaBase* SofaBaseApplication::getSelectedComponent() const
 {
-    if(m_selectedComponent == nullptr)
+    if(m_selectedComponent.get() == nullptr)
         return nullptr;
     return new SofaBase(m_selectedComponent);
 }
@@ -1227,11 +1227,11 @@ void SofaBaseApplication::setSelectedComponent(sofaqtquick::bindings::SofaBase* 
 {
     if (selectedComponent == nullptr
         || selectedComponent->rawBase() == nullptr
-        || selectedComponent->rawBase() == m_selectedComponent)
+        || selectedComponent->rawBase() == m_selectedComponent.get())
         return;
-    m_selectedComponent = selectedComponent->rawBase();
-    emit selectedComponentChanged(selectedComponent);
-    emit signalComponent(selectedComponent->getPathName());
+    m_selectedComponent = selectedComponent->base();
+    emit selectedComponentChanged(new SofaBase(m_selectedComponent));
+    emit signalComponent(QString::fromStdString(m_selectedComponent->getPathName()));
 }
 
 void SofaBaseApplication::SetSelectedComponent(sofaqtquick::bindings::SofaBase* selectedComponent)

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaBaseApplication.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaBaseApplication.cpp
@@ -98,7 +98,7 @@ SofaBaseApplication* SofaBaseApplication::OurInstance = nullptr;
 SofaBaseApplication::SofaBaseApplication(QObject* parent) : QObject(parent),
     myPythonDirectory(),
     myDataDirectory(),
-    m_selectedComponent(new SofaBase(nullptr))
+    m_selectedComponent(nullptr)
 {
     OurInstance = this;
 
@@ -1217,9 +1217,9 @@ class UseOpenGLDebugLoggerRunnable : public QRunnable
 
 sofaqtquick::bindings::SofaBase* SofaBaseApplication::getSelectedComponent() const
 {
-    if(m_selectedComponent->rawBase() == nullptr)
+    if(m_selectedComponent == nullptr)
         return nullptr;
-    return m_selectedComponent;
+    return new SofaBase(m_selectedComponent);
 }
 
 
@@ -1227,11 +1227,11 @@ void SofaBaseApplication::setSelectedComponent(sofaqtquick::bindings::SofaBase* 
 {
     if (selectedComponent == nullptr
         || selectedComponent->rawBase() == nullptr
-        || selectedComponent->rawBase() == m_selectedComponent->rawBase())
+        || selectedComponent->rawBase() == m_selectedComponent)
         return;
-    m_selectedComponent = selectedComponent;
-    emit selectedComponentChanged(m_selectedComponent);
-    emit signalComponent(m_selectedComponent->getPathName());
+    m_selectedComponent = selectedComponent->rawBase();
+    emit selectedComponentChanged(selectedComponent);
+    emit signalComponent(selectedComponent->getPathName());
 }
 
 void SofaBaseApplication::SetSelectedComponent(sofaqtquick::bindings::SofaBase* selectedComponent)

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaBaseApplication.h
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaBaseApplication.h
@@ -195,7 +195,7 @@ private:
     QString					myPythonDirectory;
     QString                 myDataDirectory;
 
-    sofa::core::objectmodel::Base* m_selectedComponent;
+    sofa::core::objectmodel::Base::SPtr m_selectedComponent;
 
     QTimer m_viewUpdater;
     std::map<QmlDDGNode*, int> m_pendingUpdates;

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaBaseApplication.h
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaBaseApplication.h
@@ -195,7 +195,7 @@ private:
     QString					myPythonDirectory;
     QString                 myDataDirectory;
 
-    sofaqtquick::bindings::SofaBase* m_selectedComponent;
+    sofa::core::objectmodel::Base* m_selectedComponent;
 
     QTimer m_viewUpdater;
     std::map<QmlDDGNode*, int> m_pendingUpdates;

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaBaseScene.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaBaseScene.cpp
@@ -235,7 +235,7 @@ void SofaBaseScene::newScene()
     sofa::simulation::graph::init();
     mySofaSimulation = sofa::simulation::graph::getSimulation();
     mySofaRootNode = mySofaSimulation->createNewNode("root");
-    myCppGraph = new SofaBase(mySofaRootNode);
+    myCppGraph = mySofaRootNode;
     setDt(mySofaRootNode->getDt());
     setStatus(Status::Ready);
     emit rootNodeChanged();
@@ -421,7 +421,7 @@ void SofaBaseScene::loadCppGraph()
         mySofaSimulation->unload(mySofaRootNode);
     }
 
-    Node* n = dynamic_cast<Node*>(myCppGraph->rawBase());
+    Node* n = dynamic_cast<Node*>(myCppGraph.get());
     if (n != nullptr)
         mySofaRootNode = sofa::simulation::Node::SPtr(n);
 
@@ -585,9 +585,9 @@ void SofaBaseScene::setSource(const QUrl& newSource)
 
 void SofaBaseScene::setCppSceneGraph(SofaBase* newCppGraph)
 {
-    if (newCppGraph->base() == myCppGraph->base())
+    if (newCppGraph->base() == myCppGraph)
         return;
-    myCppGraph = newCppGraph;
+    myCppGraph = newCppGraph->base();
 
     cppGraphChanged(newCppGraph);
 }

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaBaseScene.h
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaBaseScene.h
@@ -337,9 +337,8 @@ private:
     sofa::simulation::Node::SPtr                mySofaRootNode;
     QTimer*                                     myStepTimer;
 
-    SofaBase*                                   mySelectedComponent {nullptr};
-
-    SofaBase*                                   myCppGraph;
+    sofa::core::objectmodel::Base::SPtr         mySelectedComponent {nullptr};
+    sofa::core::objectmodel::Base::SPtr         myCppGraph;
 
     QList<QObject*>                             m_canvas;
 };

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaProject.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/SofaProject.cpp
@@ -99,6 +99,7 @@ SofaProject::SofaProject()
     m_watcher = new ProjectMonitor();
     connect(m_watcher, &ProjectMonitor::directoryChanged, this, &SofaProject::onDirectoryChanged);
     connect(m_watcher, &ProjectMonitor::fileChanged, this, &SofaProject::onFileChanged);
+    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
 }
 
 SofaProject::~SofaProject()


### PR DESCRIPTION
The consequence is that the object was hold in the c++ side but owned by javascript side.
This does not happens when letting Javascript holding every SofaXXX pointer.

The PR fix that for the SofaBaseApplication.
Warning: there is still an issue because of the use of a raw pointer instead of a smartpointer to the object so he can be destructed (when the graph is destroyed for example) but still hold there.