### PR TITLE
Fix Scene reloading

### DIFF
--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaViews/Hierarchy.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaViews/Hierarchy.qml
@@ -361,6 +361,10 @@ Rectangle {
 
         function storeExpandedState(index)
         {
+            if (index.row === 0 && index.column === 0)
+                /// Crash in mapToSource when passing index corresponding to root. dunno why..?
+                return
+
             var srcIndex = sceneModel.mapToSource(index)
             var theComponent = basemodel.getBaseFromIndex(srcIndex)
             if (theComponent === null) return;


### PR DESCRIPTION
reloading a scene while having the root node selected in the treeView causes the ProxyModel to crash when calling mapToSource