### PR TITLE
🐛 FIX linkage of datafields in inspector

### DIFF
--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/CustomInspectorWidgets/CustomInspector.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/CustomInspectorWidgets/CustomInspector.qml
@@ -11,6 +11,8 @@ ColumnLayout {
     spacing: 10
     property var component: SofaApplication.selectedComponent
 
+    property var dropGroup: ""
+    property var dropItem: null
     property var showAll: true
     property var dataDict: {"Base": ["name", "componentState", "printLog"]}
     onDataDictChanged: {
@@ -25,11 +27,68 @@ ColumnLayout {
         model: Object.keys(dataDict).length
 
         GroupBox {
+            id: dataGroup
             title: Object.keys(dataDict)[index]
             Layout.fillWidth: true
+
+            function groupOnEntered(drag) {
+                dropGroup = dataGroup.title
+                dropItem = drag.source.item
+            }
+            function groupOnExited(drag) {
+                dropGroup = ""
+                dropItem = null
+            }
+            function groupOnDropped(drag) {
+                if (drag.source.item.getPathName() === SofaApplication.selectedComponent.getPathName()) {
+                    console.error("Cannot link datafields to themselves")
+                    return;
+                }
+
+                for (var idx in SofaApplication.selectedComponent.getDataFields())
+                {
+                    var fieldName = SofaApplication.selectedComponent.getDataFields()[idx]
+                    var data = dropItem.findData(fieldName)
+                    if (data !== null && SofaApplication.selectedComponent.getData(fieldName).isAutoLink()) {
+                        if (SofaApplication.selectedComponent.getData(fieldName).getGroup().toString() === dropGroup.toString()) {
+                            SofaApplication.selectedComponent.getData(fieldName).setValue(data.value)
+                            SofaApplication.selectedComponent.getData(fieldName).setParent(data)
+                        }
+                    }
+                }
+                dropGroup = ""
+                dropItem = null
+                SofaApplication.selectedComponent = SofaApplication.selectedComponent
+            }
+
             ColumnLayout {
+                id: groupLayout
                 spacing: 1
                 anchors.fill: parent
+
+                MouseArea {
+                    id: mGroupArea
+                    width:  groupLayout.width
+                    height: groupLayout.height
+                    hoverEnabled: true
+
+
+                    DropArea {
+                        id: dropGroupArea
+                        keys: ["text/plain"]
+                        anchors.fill: parent
+                        onEntered: {
+                            groupOnEntered(drag)
+                        }
+                        onExited: {
+                            groupOnExited(drag)
+                        }
+
+                        onDropped: {
+                            groupOnDropped(drag)
+                        }
+                    }
+                }
                 Repeater {
                     id: dataRepeater
                     model: dataDict[Object.keys(dataDict)[index]]
@@ -46,6 +105,23 @@ ColumnLayout {
                             text:  modelData
                             color: sofaDataLayout.sofaData.properties.required && !sofaDataLayout.sofaData.properties.set ? "red" : "black"
                             elide: Text.ElideRight
+
+                            Rectangle {
+                                id: dataFrame
+                                color: "transparent"
+                                border.color: "red"
+                                border.width: 1
+                                anchors.fill: parent
+                                visible: {
+                                    if (dropGroup === dataGroup.title || dropGroup == "all")
+                                    {
+                                        if (dropItem && dropItem.findData(modelData))
+                                            return true
+                                    }
+                                    return false
+                                }
+                            }
+
                             ToolTip {
                                 text: sofaDataLayout.sofaData.getName()
                                 description: sofaDataLayout.sofaData.getHelp()
@@ -57,10 +133,24 @@ ColumnLayout {
                                 anchors.fill: parent
                                 hoverEnabled: true
                                 onPressed: forceActiveFocus()
+
                                 DropArea {
                                     id: dropArea
                                     keys: ["text/plain"]
                                     anchors.fill: parent
+                                    onEntered: {
+                                        if (drag.source.item.getPathName() === SofaApplication.selectedComponent.getPathName()) {
+                                            return;
+                                        }
+                                        var data = drag.source.item.findData(sofaData.getName())
+                                        if (sofaData.getValueType() === "PrefabLink" || data !== null) {
+                                            dataFrame.visible = true
+                                        }
+                                    }
+                                    onExited: {
+                                        dataFrame.visible = false
+                                    }
+
                                     onDropped: {
                                         if (sofaData.getValueType() === "PrefabLink") {
                                             sofaData.value = "@" + drag.source.item.getPathName()
@@ -71,11 +161,12 @@ ColumnLayout {
                                             console.error("Cannot link datafields to themselves")
                                             return;
                                         }
-                                        var data = drag.source.item.getData(sofaData.getName())
+                                        var data = drag.source.item.findData(sofaData.getName())
                                         if (data !== null) {
                                             sofaData.setValue(data.value)
                                             sofaData.setParent(data)
                                         }
+                                        dataFrame.visible = false
                                     }
                                 }
                             }

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaBasics/GroupBox.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaBasics/GroupBox.qml
@@ -15,7 +15,13 @@ GroupBox {
     property int expandedHeight: 0
     property url titleIcon
     property string buttonIconSource: ""
+    property string borderColor: "transparent"
+
+
     signal buttonClicked
+    signal labelOnEntered
+    signal labelOnExited
+    signal labelOnDropped
 
     onExpandedChanged: {
         contentItem.visible = expanded
@@ -32,12 +38,9 @@ GroupBox {
     bottomPadding: 0
 
     label: Rectangle {
+        id: lblRect
         anchors.fill: parent
         color: "transparent"
-        MouseArea {
-            anchors.fill: parent
-            onPressed: forceActiveFocus()
-        }
 
         Rectangle {
             y: 0
@@ -85,6 +88,27 @@ GroupBox {
             elide: Text.ElideRight
             anchors.left: titleIconId.right
             anchors.leftMargin: 5
+            MouseArea {
+                width:  label.width
+                height: label.height
+                hoverEnabled: true
+
+
+                DropArea {
+                    id: dropGroupArea
+                    keys: ["text/plain"]
+                    anchors.fill: parent
+                    onEntered: {
+                        groupOnEntered(drag)
+                    }
+                    onExited: {
+                        groupOnExited(drag)
+                    }
+
+                    onDropped: {
+                        groupOnDropped(drag)
+                    }
+                }            }
         }
         Button {
             id: extraButton
@@ -115,15 +139,16 @@ GroupBox {
     }
     background: Rectangle {
         anchors.fill: parent
-
+        border.color: control.borderColor
+        border.width: 1
         color: "transparent"
-        MouseArea {
-            anchors.fill: parent
-            onPressed: {
-                print( "Mouse area pressed in a rectangle.")
-                forceActiveFocus()
-            }
-        }
+//        MouseArea {
+//            anchors.fill: parent
+//            onPressed: {
+//                print( "Mouse area pressed in a rectangle.")
+//                forceActiveFocus()
+//            }
+//        }
 
     }  
 }

--- a/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaBasics/SofaLinkItem.qml
+++ b/applications-dev/plugins/SofaQtQuickGUI/data/qml/SofaBasics/SofaLinkItem.qml
@@ -101,14 +101,15 @@ ColumnLayout {
                 model: SofaLinkCompletionModel {
                     id: completionModel
                     sofaData: control.sofaData
+                    isComponent: false
                     onModelReset: {
                         listView.implicitHeight = completionModel.rowCount() * 20
                         parent.contentHeight = completionModel.rowCount() * 20
                         parent.height = parent.contentHeight
                     }
                 }
-                Keys.onTabPressed: {
-                    console.log("TAB pressed (in listView)")
+
+                function selectCurrentCompletion() {
                     txtField.text = listView.currentItem.text
                     if (txtField.isLinkValid(listView.currentItem.text)) {
                         console.log("valid linkPath")
@@ -119,11 +120,20 @@ ColumnLayout {
                     }
                 }
 
+                Keys.onTabPressed: {
+                    selectCurrentCompletion()
+                }
+
+                Keys.onRightPressed: {
+                    selectCurrentCompletion()
+                }
+
                 Keys.onDownPressed: {
                     currentIndex++
                     if (currentIndex >= listView.rowCount)
                         currentIndex = listView.rowCount - 1
                 }
+
 
                 delegate: Rectangle {
                     id: delegateId

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Models/SofaLinkCompletionModel.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Models/SofaLinkCompletionModel.cpp
@@ -148,7 +148,7 @@ void SofaLinkCompletionModel::updateModel()
         }
     }
 
-    if (m_isComponent)
+    if (!m_isComponent)
     {
         for (auto data : lastValid->getDataFields())
         {


### PR DESCRIPTION
- ADD visual feedback when dropping hierarchy item on Inspector (all fields, group & individual datafield
- FIX refresh of datafields after dropping links
- FIX autocompletion of data links (not just component but data names too)
- IMPROVE autocompletion interaction (enter: selects and de-focus, right/TAB: narrows down selection with current item)