### PR TITLE
🐛 FIX edition of dynamicTableViews containing text vectors

### DIFF
--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/DataHelper.cpp
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/DataHelper.cpp
@@ -447,7 +447,35 @@ QVariantMap& convertDataInfoToProperties(const BaseData* data, QVariantMap& prop
 
     /// Default type...
     properties.insert("type","array");
-    return properties;
+
+
+    if(typeinfo->Integer())
+    {
+        if(std::string::npos != typeinfo->BaseType()->name().find("bool"))
+        {
+            properties.insert("subtype", "boolean");
+            return properties;
+        }
+
+        properties.insert("subtype", "number");
+        properties.insert("decimals", 0);
+        if(std::string::npos != typeinfo->name().find("unsigned"))
+            properties.insert("min", 0);
+        return properties;
+    }
+    if(typeinfo->Scalar())
+    {
+        properties.insert("subtype", "number");
+        properties.insert("step", 0.1);
+        properties.insert("precision", 6);
+        return properties;
+    }
+
+    if(typeinfo->Text())
+    {
+        properties.insert("subtype", "string");
+        return properties;
+    }
 }
 
 

--- a/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Models/SofaDataContainerListModel.h
+++ b/applications-dev/plugins/SofaQtQuickGUI/src/SofaQtQuickGUI/Models/SofaDataContainerListModel.h
@@ -68,6 +68,9 @@ private:
         if (!m_sofaData) return 0;
 
         auto typeinfo = m_sofaData->rawData()->getValueTypeInfo();
+
+        if (typeinfo->Text())
+            return 1;
         int nbCols = int(typeinfo->BaseType()->size());
         if (nbCols == 1)
             return int(typeinfo->size());
@@ -78,6 +81,10 @@ private:
     {
         if (!m_sofaData) return 0;
         auto typeinfo = m_sofaData->rawData()->getValueTypeInfo();
+
+        if (typeinfo->Text())
+            return int(typeinfo->size(m_sofaData->rawData()->getValueVoidPtr()));
+
         return int(typeinfo->size(m_sofaData->rawData()->getValueVoidPtr()) / size_t(nCols()));
     }
 };


### PR DESCRIPTION
Limitations to this feature include sets (can't resize) & 2D vectors of strings (unsupported)

Improves support of number types (singed / unsigned, int/scalar, bool) using validators
Improves interaction by validating new row with Enter
Adds subtype property in data properties to get info on Container's BaseTypes